### PR TITLE
 Fixed the parsing of the env files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ## BUG FIXES
 
-* Fixed the parsing of the env files in `~/.lamin` due to changes in the lamindb-setup Python package (PR #xx).
+* Fixed the parsing of the env files in `~/.lamin` due to changes in the lamindb-setup Python package (PR #12).
 
 # laminr v0.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   - Linting action.
   - Commands for roxygenizing (`/document`) and restyling the source code (`/style`).
 
+## BUG FIXES
+
+* Fixed the parsing of the env files in `~/.lamin` due to changes in the lamindb-setup Python package (PR #xx).
+
 # laminr v0.0.1
 
 Initial POC implementation of the LaminDB API client for R.

--- a/R/settings_store.R
+++ b/R/settings_store.R
@@ -85,7 +85,8 @@
     name <- gsub(env_prefix, "", name_with_prefix)
 
     if (!name %in% names(field_types)) {
-      cli_abort(paste0("Unknown field: ", name))
+      cli_warn(paste0("Unexpected field in '", env_file, "': ", name))
+      return(list(name = name, value = NULL))
     }
     raw_type <- field_types[[name]]
 
@@ -120,12 +121,14 @@
   env_prefix <- "lamindb_instance_"
 
   field_types <- list(
+    api_url = "Optional[str]",
     owner = "str",
     name = "str",
     storage_root = "str",
     storage_region = "str",
     db = "Optional[str]",
     schema_str = "Optional[str]",
+    schema_id = "Optional[str]",
     id = "str",
     git_repo = "Optional[str]",
     keep_artifacts_local = "Optional[bool]"
@@ -141,6 +144,7 @@
     email = "str",
     password = "str",
     access_token = "str",
+    api_key = "Optional[str]",
     uid = "str",
     uuid = "str",
     handle = "str",


### PR DESCRIPTION
## BUG FIXES

* Fixed the parsing of the env files in `~/.lamin` due to changes in the lamindb-setup Python package (PR #xx).