### PR TITLE
Log into Lamin in CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,16 +29,10 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      LAMIN_API_KEY: ${{ secrets.LAMIN_API_KEY_TESTUSER1 }}
 
     steps:
       - uses: actions/checkout@v4
-
-      # - name: Install lamin-cli
-      #   env:
-      #     LAMIN_API_KEY: ${{ secrets.LAMIN_API_KEY }}
-      #   run: |
-      #     pip install lamin-cli
-      #     lamin login
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -49,6 +43,18 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
+
+      - name: Install lamindb
+        run: |
+          pip install lamindb[bionty]
+
+      - name: Log in to Lamin
+        run: |
+          lamin login
+
+      - name: Set cellxgene as default instance
+        run: |
+          lamin load laminlabs/cellxgene
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -16,13 +16,18 @@ permissions: read-all
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
+
     # Only restrict concurrency for non-PR jobs
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      LAMIN_API_KEY: ${{ secrets.LAMIN_API_KEY_TESTUSER1 }}
+
     permissions:
       contents: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -37,12 +42,17 @@ jobs:
           extra-packages: any::pkgdown, local::.
           needs: website
 
-      # - name: Install lamin-cli
-      #   env:
-      #     LAMIN_API_KEY: ${{ secrets.LAMIN_API_KEY }}
-      #   run: |
-      #     pip install lamin-cli
-      #     lamin login
+      - name: Install lamindb
+        run: |
+          pip install lamindb[bionty]
+
+      - name: Log in to Lamin
+        run: |
+          lamin login
+
+      - name: Set cellxgene as default instance
+        run: |
+          lamin load laminlabs/cellxgene
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 * Generate vignettes using Quarto (PR #13).
 
+* Define a current user and current instance with lamin-cli prior to testing and generating documentation in the CI (PR #23).
+
 ## BUG FIXES
 
 * Fixed the parsing of the env files in `~/.lamin` due to changes in the lamindb-setup Python package (PR #12).


### PR DESCRIPTION
## Minor changes

* Define a current user and current instance with lamin-cli prior to testing and generating documentation in the CI.