### PR TITLE
Add printing to remaining classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * Add `to_string()` and `print()` methods to the `Record` class and (incomplete) `describe()` method to the `Artifact()` class (PR #22)
 
+* Add `to_string()` and `print()` methods to remaining classes (PR #31)
+
 ## MAJOR CHANGES
 
 * Refactored the internal class data structures for better modularity and extensibility (PR #8).

--- a/R/Artifact.R
+++ b/R/Artifact.R
@@ -8,10 +8,9 @@ ArtifactRecord <- R6::R6Class( # nolint object_name_linter
   "ArtifactRecord",
   inherit = Record,
   public = list(
-    #' Load the artifact into memory
-    #'
     #' @description
-    #' This currently only supports AnnData artifacts.
+    #' Load the artifact into memory. This currently only supports AnnData
+    #' artifacts.
     #'
     #' @return The artifact
     load = function() {
@@ -26,10 +25,9 @@ ArtifactRecord <- R6::R6Class( # nolint object_name_linter
         cli_abort(paste0("Unsupported accessor: ", artifact_accessor))
       }
     },
-    #' Cache the artifact to the local filesystem
-    #'
     #' @description
-    #' This currently only supports S3 storage.
+    #' Cache the artifact to the local filesystem. This currently only supports
+    #' S3 storage.
     #'
     #' @return The path to the cached artifact
     cache = function() {
@@ -50,6 +48,10 @@ ArtifactRecord <- R6::R6Class( # nolint object_name_linter
         cli_abort(paste0("Unsupported storage type: ", artifact_storage$type))
       }
     },
+    #' @description
+    #' Print a more detailed description of an `ArtifactRecord`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
     describe = function(style = TRUE) {
       provenance_fields <- c(
         storage = "root",

--- a/R/Field.R
+++ b/R/Field.R
@@ -53,6 +53,12 @@ Field <- R6::R6Class( # nolint object_name_linter
     print = function(style = TRUE) {
       cli::cat_line(self$to_string(style))
     },
+    #' @description
+    #' Create a string representation of a `Field`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
+    #'
+    #' @return A `cli::cli_ansi_string` if `style = TRUE` or a character vector
     to_string = function(style = FALSE) {
       field_strings <- make_key_value_strings(
         self,

--- a/R/Field.R
+++ b/R/Field.R
@@ -46,11 +46,14 @@ Field <- R6::R6Class( # nolint object_name_linter
       private$.related_registry_name <- related_registry_name
       private$.related_module_name <- related_module_name
     },
+    #' @description
+    #' Print a `Field`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
     print = function(style = TRUE) {
       cli::cat_line(self$to_string(style))
     },
     to_string = function(style = FALSE) {
-
       field_strings <- make_key_value_strings(
         self,
         c(

--- a/R/Field.R
+++ b/R/Field.R
@@ -45,6 +45,30 @@ Field <- R6::R6Class( # nolint object_name_linter
       private$.related_field_name <- related_field_name
       private$.related_registry_name <- related_registry_name
       private$.related_module_name <- related_module_name
+    },
+    print = function(style = TRUE) {
+      cli::cat_line(self$to_string(style))
+    },
+    to_string = function(style = FALSE) {
+
+      field_strings <- make_key_value_strings(
+        self,
+        c(
+          "field_name",
+          "column_name",
+          "type",
+          "registry_name",
+          "module_name",
+          "through",
+          "is_link_table",
+          "relation_type",
+          "related_field_name",
+          "related_registry_name",
+          "related_module_name"
+        )
+      )
+
+      make_class_string("Field", field_strings, style = style)
     }
   ),
   private = list(

--- a/R/Instance.R
+++ b/R/Instance.R
@@ -119,22 +119,18 @@ Instance <- R6::R6Class( # nolint object_name_linter
     },
 
     to_string = function(style = FALSE)  {
-      string <- paste0(
-        cli::style_bold(cli::col_green(
-          paste(private$.settings$name, "Instance")
-        )), "(",
-        cli::col_blue("modules"), cli::col_br_blue("="),
-        cli::col_yellow(
-          paste0("c('", paste(self$get_module_names(), collapse = "', '"), "')")
-        ),
-        ")"
+
+      fields <- list(
+        modules = paste0(
+          "c('", paste(self$get_module_names(), collapse = "', '"), "')"
+        )
       )
 
-      if (isFALSE(style)) {
-        string <- cli::ansi_strip(string)
-      }
+      field_strings <- make_key_value_strings(fields)
 
-      return(string)
+      make_class_string(
+        paste(private$.settings$name, "Instance"), field_strings, style = style
+      )
     }
   ),
 

--- a/R/Instance.R
+++ b/R/Instance.R
@@ -105,6 +105,15 @@ Instance <- R6::R6Class( # nolint object_name_linter
     get_module_names = function() {
       names(private$.module_classes)
     },
+    #' Get instance settings.
+    get_settings = function() {
+      private$.settings
+    },
+    #' Get instance API.
+    get_api = function() {
+      private$.api
+    },
+
     print = function(style = TRUE) {
       cli::cat_line(self$to_string(style))
     },

--- a/R/Instance.R
+++ b/R/Instance.R
@@ -113,13 +113,20 @@ Instance <- R6::R6Class( # nolint object_name_linter
     get_api = function() {
       private$.api
     },
-
+    #' @description
+    #' Print an `Instance`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
     print = function(style = TRUE) {
       cli::cat_line(self$to_string(style))
     },
-
-    to_string = function(style = FALSE)  {
-
+    #' @description
+    #' Create a string representation of an `Instance`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
+    #'
+    #' @return A `cli::cli_ansi_string` if `style = TRUE` or a character vector
+    to_string = function(style = FALSE) {
       fields <- list(
         modules = paste0(
           "c('", paste(self$get_module_names(), collapse = "', '"), "')"
@@ -129,11 +136,11 @@ Instance <- R6::R6Class( # nolint object_name_linter
       field_strings <- make_key_value_strings(fields)
 
       make_class_string(
-        paste(private$.settings$name, "Instance"), field_strings, style = style
+        paste(private$.settings$name, "Instance"), field_strings,
+        style = style
       )
     }
   ),
-
   private = list(
     .settings = NULL,
     .api = NULL,

--- a/R/Instance.R
+++ b/R/Instance.R
@@ -198,7 +198,7 @@ Instance <- R6::R6Class( # nolint object_name_linter
       module_names <- module_names[module_names != "core"]
 
       if (length(module_names) > 0) {
-        mapping["AdditionModules"] = paste0(
+        mapping["AdditionalModules"] <- paste0(
           "[",
           paste(module_names, collapse = ", "),
           "]"

--- a/R/Instance.R
+++ b/R/Instance.R
@@ -104,8 +104,31 @@ Instance <- R6::R6Class( # nolint object_name_linter
     #' Get the names of the modules. Example: `c("core", "bionty")`.
     get_module_names = function() {
       names(private$.module_classes)
+    },
+    print = function(style = TRUE) {
+      cli::cat_line(self$to_string(style))
+    },
+
+    to_string = function(style = FALSE)  {
+      string <- paste0(
+        cli::style_bold(cli::col_green(
+          paste(private$.settings$name, "Instance")
+        )), "(",
+        cli::col_blue("modules"), cli::col_br_blue("="),
+        cli::col_yellow(
+          paste0("c('", paste(self$get_module_names(), collapse = "', '"), "')")
+        ),
+        ")"
+      )
+
+      if (isFALSE(style)) {
+        string <- cli::ansi_strip(string)
+      }
+
+      return(string)
     }
   ),
+
   private = list(
     .settings = NULL,
     .api = NULL,

--- a/R/InstanceAPI.R
+++ b/R/InstanceAPI.R
@@ -16,6 +16,7 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
     initialize = function(instance_settings) {
       private$.instance_settings <- instance_settings
     },
+    #' @description
     #' Get the schema for the instance.
     get_schema = function() {
       # TODO: replace with laminr.api get_schema call
@@ -35,7 +36,9 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
 
       content
     },
+    #' @description
     #' Get a record from the instance.
+    #'
     #' @importFrom jsonlite toJSON
     get_record = function(module_name,
                           registry_name,

--- a/R/InstanceAPI.R
+++ b/R/InstanceAPI.R
@@ -102,6 +102,37 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
       }
 
       content
+    },
+    print = function(style = TRUE) {
+      cli::cat_line(self$to_string(style))
+    },
+
+    to_string = function(style = FALSE)  {
+      field_strings <- purrr::map_chr(
+        c("api_url", "id", "schema_id"), function(.name) {
+          value <- private$.instance_settings[[.name]]
+
+          if (is.character(value)) {
+            value <- paste0("'", value, "'")
+          }
+
+          paste0(
+            cli::col_blue(.name), cli::col_br_blue("="), cli::col_yellow(value)
+          )
+        }
+      )
+
+      string <- paste0(
+        cli::style_bold(cli::col_green("API")), "(",
+        paste(field_strings, collapse = ", "),
+        ")"
+      )
+
+      if (isFALSE(style)) {
+        string <- cli::ansi_strip(string)
+      }
+
+      return(string)
     }
   ),
   private = list(

--- a/R/InstanceAPI.R
+++ b/R/InstanceAPI.R
@@ -103,11 +103,20 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
 
       content
     },
+    #' @description
+    #' Print an `API`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
     print = function(style = TRUE) {
       cli::cat_line(self$to_string(style))
     },
-
-    to_string = function(style = FALSE)  {
+    #' @description
+    #' Create a string representation of an `API`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
+    #'
+    #' @return A `cli::cli_ansi_string` if `style = TRUE` or a character vector
+    to_string = function(style = FALSE) {
       field_strings <- make_key_value_strings(
         private$.instance_settings, c("api_url", "id", "schema_id")
       )
@@ -119,4 +128,3 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
     .instance_settings = NULL
   )
 )
-

--- a/R/InstanceAPI.R
+++ b/R/InstanceAPI.R
@@ -108,34 +108,15 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
     },
 
     to_string = function(style = FALSE)  {
-      field_strings <- purrr::map_chr(
-        c("api_url", "id", "schema_id"), function(.name) {
-          value <- private$.instance_settings[[.name]]
-
-          if (is.character(value)) {
-            value <- paste0("'", value, "'")
-          }
-
-          paste0(
-            cli::col_blue(.name), cli::col_br_blue("="), cli::col_yellow(value)
-          )
-        }
+      field_strings <- make_key_value_strings(
+        private$.instance_settings, c("api_url", "id", "schema_id")
       )
 
-      string <- paste0(
-        cli::style_bold(cli::col_green("API")), "(",
-        paste(field_strings, collapse = ", "),
-        ")"
-      )
-
-      if (isFALSE(style)) {
-        string <- cli::ansi_strip(string)
-      }
-
-      return(string)
+      make_class_string("API", field_strings, style = style)
     }
   ),
   private = list(
     .instance_settings = NULL
   )
 )
+

--- a/R/InstanceSettings.R
+++ b/R/InstanceSettings.R
@@ -47,12 +47,20 @@ InstanceSettings <- R6::R6Class( # nolint object_name_linter
       }
       private$.settings <- settings
     },
+    #' @description
+    #' Print an `InstanceSettings`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
     print = function(style = TRUE) {
       cli::cat_line(self$to_string(style))
     },
-
-    to_string = function(style = FALSE)  {
-
+    #' @description
+    #' Create a string representation of an `InstanceSettings`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
+    #'
+    #' @return A `cli::cli_ansi_string` if `style = TRUE` or a character vector
+    to_string = function(style = FALSE) {
       field_strings <- make_key_value_strings(private$.settings)
 
       make_class_string("InstanceSettings", field_strings, style = style)

--- a/R/InstanceSettings.R
+++ b/R/InstanceSettings.R
@@ -46,6 +46,44 @@ InstanceSettings <- R6::R6Class( # nolint object_name_linter
         cli_abort("Unexpected column: ", unexpected_columns)
       }
       private$.settings <- settings
+    },
+    print = function(style = TRUE) {
+      cli::cat_line(self$to_string(style))
+    },
+
+    to_string = function(style = FALSE)  {
+
+
+      settings_strings <- purrr::map_chr(
+        names(private$.settings), function(.name) {
+          value <- private$.settings[[.name]]
+
+          if (is.null(value)) {
+            return(NA_character_)
+          }
+
+          if (is.character(value)) {
+            value <- paste0("'", value, "'")
+          }
+
+          paste0(
+            cli::col_blue(.name), cli::col_br_blue("="), cli::col_yellow(value)
+          )
+        }
+      ) |>
+        purrr::discard(is.na)
+
+      string <- paste0(
+        cli::style_bold(cli::col_green("InstanceSettings")), "(",
+        paste(settings_strings, collapse = ", "),
+        ")"
+      )
+
+      if (isFALSE(style)) {
+        string <- cli::ansi_strip(string)
+      }
+
+      return(string)
     }
   ),
   private = list(

--- a/R/InstanceSettings.R
+++ b/R/InstanceSettings.R
@@ -53,37 +53,9 @@ InstanceSettings <- R6::R6Class( # nolint object_name_linter
 
     to_string = function(style = FALSE)  {
 
+      field_strings <- make_key_value_strings(private$.settings)
 
-      settings_strings <- purrr::map_chr(
-        names(private$.settings), function(.name) {
-          value <- private$.settings[[.name]]
-
-          if (is.null(value)) {
-            return(NA_character_)
-          }
-
-          if (is.character(value)) {
-            value <- paste0("'", value, "'")
-          }
-
-          paste0(
-            cli::col_blue(.name), cli::col_br_blue("="), cli::col_yellow(value)
-          )
-        }
-      ) |>
-        purrr::discard(is.na)
-
-      string <- paste0(
-        cli::style_bold(cli::col_green("InstanceSettings")), "(",
-        paste(settings_strings, collapse = ", "),
-        ")"
-      )
-
-      if (isFALSE(style)) {
-        string <- cli::ansi_strip(string)
-      }
-
-      return(string)
+      make_class_string("InstanceSettings", field_strings, style = style)
     }
   ),
   private = list(

--- a/R/Module.R
+++ b/R/Module.R
@@ -86,8 +86,11 @@ Module <- R6::R6Class( # nolint object_name_linter
     get_registry_names = function() {
       names(private$.registry_classes)
     },
+    #' @description
+    #' Print a `Module`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
     print = function(style = TRUE) {
-
       registries <- self$get_registries()
 
       is_link_table <- purrr::map(registries, "is_link_table") |>
@@ -96,7 +99,7 @@ Module <- R6::R6Class( # nolint object_name_linter
       standard_lines <- purrr::map_chr(
         names(registries)[!is_link_table],
         function(.registry) {
-            cli::col_blue(paste0("    $", registries[[.registry]]$class_name))
+          cli::col_blue(paste0("    $", registries[[.registry]]$class_name))
         }
       )
 
@@ -121,9 +124,13 @@ Module <- R6::R6Class( # nolint object_name_linter
 
       purrr::walk(lines, cli::cat_line)
     },
-
-    to_string = function(style = FALSE)  {
-
+    #' @description
+    #' Create a string representation of a `Module`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
+    #'
+    #' @return A `cli::cli_ansi_string` if `style = TRUE` or a character vector
+    to_string = function(style = FALSE) {
       registries <- self$get_registries()
 
       is_link_table <- purrr::map(registries, "is_link_table") |>

--- a/R/Module.R
+++ b/R/Module.R
@@ -85,6 +85,73 @@ Module <- R6::R6Class( # nolint object_name_linter
     #' Get the names of the registries in the module. E.g. `c("User", "Artifact")`.
     get_registry_names = function() {
       names(private$.registry_classes)
+    },
+    print = function(style = TRUE) {
+
+      registries <- self$get_registries()
+
+      is_link_table <- purrr::map(registries, "is_link_table") |>
+        unlist()
+
+      standard_lines <- purrr::map_chr(
+        names(registries)[!is_link_table],
+        function(.registry) {
+            cli::col_blue(paste0("    $", registries[[.registry]]$class_name))
+        }
+      )
+
+      link_lines <- purrr::map_chr(
+        names(registries)[is_link_table],
+        function(.registry) {
+          cli::col_blue(paste0("    ", .registry))
+        }
+      )
+
+      lines <- c(
+        cli::style_bold(cli::col_green(private$.module_name)),
+        cli::style_italic(cli::col_magenta("  Registries")),
+        standard_lines,
+        cli::style_italic(cli::col_magenta("  Link tables")),
+        link_lines
+      )
+
+      if (isFALSE(style)) {
+        lines <- cli::ansi_strip(lines)
+      }
+
+      purrr::walk(lines, cli::cat_line)
+    },
+
+    to_string = function(style = FALSE)  {
+
+      registries <- self$get_registries()
+
+      is_link_table <- purrr::map(registries, "is_link_table") |>
+        unlist()
+
+      registry_strings <- make_key_value_strings(
+        list(
+          "Registries" = paste0(
+            "[",
+            paste(
+              paste0(
+                "$",
+                purrr::map_chr(registries[!is_link_table], "class_name")
+              ),
+              collapse = ", "
+            ),
+            "]"
+          ),
+          "LinkTables" = paste0(
+            "[",
+            paste(names(registries[is_link_table]), collapse = ", "),
+            "]"
+          )
+        ),
+        quote_strings = FALSE
+      )
+
+      make_class_string(private$.module_name, registry_strings, style = style)
     }
   ),
   private = list(

--- a/R/Module.R
+++ b/R/Module.R
@@ -74,14 +74,17 @@ Module <- R6::R6Class( # nolint object_name_linter
       ) |>
         set_names(names(module_schema))
     },
+    #' @description
     #' Get the registries in the module.
     get_registries = function() {
       private$.registry_classes
     },
+    #' @description
     #' Get a registry by name.
     get_registry = function(registry_name) {
       private$.registry_classes[[registry_name]]
     },
+    #' @description
     #' Get the names of the registries in the module. E.g. `c("User", "Artifact")`.
     get_registry_names = function() {
       names(private$.registry_classes)

--- a/R/Record.R
+++ b/R/Record.R
@@ -122,34 +122,11 @@ Record <- R6::R6Class( # nolint object_name_linter
         important_fields, setdiff(names(record_fields), important_fields)
       )
 
-      field_strings <- purrr::map_chr(field_names, function(.name) {
-        value <- record_fields[[.name]]
+      field_strings <- make_key_value_strings(record_fields, field_names)
 
-        if (is.null(value)) {
-          return(NA_character_)
-        }
-
-        if (is.character(value)) {
-          value <- paste0("'", value, "'")
-        }
-
-        paste0(
-          cli::col_blue(.name), cli::col_br_blue("="), cli::col_yellow(value)
-        )
-      }) |>
-        purrr::discard(is.na)
-
-      string <- paste0(
-        cli::style_bold(cli::col_green(private$.registry$class_name)), "(",
-        paste(field_strings, collapse = ", "),
-        ")"
+      make_class_string(
+        private$.registry$class_name, field_strings, style = style
       )
-
-      if (isFALSE(style)) {
-        string <- cli::ansi_strip(string)
-      }
-
-      return(string)
     }
   ),
   private = list(

--- a/R/Record.R
+++ b/R/Record.R
@@ -95,9 +95,19 @@ Record <- R6::R6Class( # nolint object_name_linter
         )
       }
     },
+    #' @description
+    #' Print a `Record`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
     print = function(style = TRUE) {
       cli::cat_line(self$to_string(style))
     },
+    #' @description
+    #' Create a string representation of a `Record`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
+    #'
+    #' @return A `cli::cli_ansi_string` if `style = TRUE` or a character vector
     to_string = function(style = FALSE) {
       important_fields <- c(
         "uid",
@@ -125,7 +135,8 @@ Record <- R6::R6Class( # nolint object_name_linter
       field_strings <- make_key_value_strings(record_fields, field_names)
 
       make_class_string(
-        private$.registry$class_name, field_strings, style = style
+        private$.registry$class_name, field_strings,
+        style = style
       )
     }
   ),

--- a/R/Registry.R
+++ b/R/Registry.R
@@ -76,8 +76,11 @@ Registry <- R6::R6Class( # nolint object_name_linter
     get_record_class = function() {
       private$.record_class
     },
+    #' @description
+    #' Print a `Registry`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
     print = function(style = TRUE) {
-
       fields <- self$get_fields()
       # Remove hidden fields
       fields <- fields[grep("^_", names(fields), value = TRUE, invert = TRUE)]
@@ -93,7 +96,8 @@ Registry <- R6::R6Class( # nolint object_name_linter
         function(.field) {
           paste0(
             cli::col_blue(paste0("    ", .field)), ": ",
-            cli::col_grey(fields[[.field]]$type))
+            cli::col_grey(fields[[.field]]$type)
+          )
         }
       )
 
@@ -110,9 +114,9 @@ Registry <- R6::R6Class( # nolint object_name_linter
 
       lines <- c(
         cli::style_bold(cli::col_green(private$.class_name)),
-        cli::style_italic(cli::col_magenta("  Simple fields")),
+        cli::style_italic(cli::col_br_magenta("  Simple fields")),
         simple_lines,
-        cli::style_italic(cli::col_magenta("  Relational fields")),
+        cli::style_italic(cli::col_br_magenta("  Relational fields")),
         relational_lines
       )
 
@@ -122,9 +126,13 @@ Registry <- R6::R6Class( # nolint object_name_linter
 
       purrr::walk(lines, cli::cat_line)
     },
-
-    to_string = function(style = FALSE)  {
-
+    #' @description
+    #' Create a string representation of a `Registry`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
+    #'
+    #' @return A `cli::cli_ansi_string` if `style = TRUE` or a character vector
+    to_string = function(style = FALSE) {
       fields <- self$get_fields()
       # Remove hidden fields
       fields <- fields[grep("^_", names(fields), value = TRUE, invert = TRUE)]
@@ -153,7 +161,6 @@ Registry <- R6::R6Class( # nolint object_name_linter
 
       make_class_string(private$.class_name, field_strings, style = style)
     }
-
   ),
   private = list(
     .instance = NULL,

--- a/R/Registry.R
+++ b/R/Registry.R
@@ -81,6 +81,8 @@ Registry <- R6::R6Class( # nolint object_name_linter
       fields <- self$get_fields()
       # Remove hidden fields
       fields <- fields[grep("^_", names(fields), value = TRUE, invert = TRUE)]
+      # Remove link fields
+      fields <- fields[grep("^links_", names(fields), value = TRUE, invert = TRUE)]
 
       relational_fields <- purrr::map(fields, "relation_type") |>
         unlist() |>
@@ -126,6 +128,8 @@ Registry <- R6::R6Class( # nolint object_name_linter
       fields <- self$get_fields()
       # Remove hidden fields
       fields <- fields[grep("^_", names(fields), value = TRUE, invert = TRUE)]
+      # Remove link fields
+      fields <- fields[grep("^links_", names(fields), value = TRUE, invert = TRUE)]
 
       relational_fields <- purrr::map(fields, "relation_type") |>
         unlist() |>

--- a/R/Registry.R
+++ b/R/Registry.R
@@ -92,7 +92,7 @@ Registry <- R6::R6Class( # nolint object_name_linter
         setdiff(names(fields), relational_fields),
         function(.field) {
           paste0(
-            cli::col_blue(paste0("    $", .field)), ": ",
+            cli::col_blue(paste0("    ", .field)), ": ",
             cli::col_grey(fields[[.field]]$type))
         }
       )
@@ -100,7 +100,7 @@ Registry <- R6::R6Class( # nolint object_name_linter
       relational_lines <- purrr::map_chr(relational_fields, function(.field) {
         field_object <- fields[[.field]]
         paste0(
-          cli::col_blue(paste0("    $", .field)), ": ",
+          cli::col_blue(paste0("    ", .field)), ": ",
           cli::col_grey(paste0(
             field_object$related_registry_name,
             " (", field_object$relation_type, ")"
@@ -139,15 +139,12 @@ Registry <- R6::R6Class( # nolint object_name_linter
         list(
           "SimpleFields" = paste0(
             "[",
-            paste(
-              paste0("$", setdiff(names(fields), relational_fields)),
-              collapse = ", "
-            ),
+            paste(setdiff(names(fields), relational_fields), collapse = ", "),
             "]"
           ),
           "RelationalFields" = paste0(
             "[",
-            paste(paste0("$", relational_fields), collapse = ", "),
+            paste(relational_fields, collapse = ", "),
             "]"
           )
         ),

--- a/R/Registry.R
+++ b/R/Registry.R
@@ -48,6 +48,7 @@ Registry <- R6::R6Class( # nolint object_name_linter
         api = api
       )
     },
+    #' @description
     #' Get a record by ID or UID.
     get = function(id_or_uid, include_foreign_keys = FALSE, verbose = FALSE) {
       data <- private$.api$get_record(
@@ -60,18 +61,22 @@ Registry <- R6::R6Class( # nolint object_name_linter
 
       private$.record_class$new(data = data)
     },
+    #' @description
     #' Get the fields in the registry.
     get_fields = function() {
       private$.fields
     },
+    #' @description
     #' Get a field by name.
     get_field = function(field_name) {
       private$.fields[[field_name]]
     },
+    #' @description
     #' Get the field names in the registry.
     get_field_names = function() {
       names(private$.fields)
     },
+    #' @description
     #' Get the record class for the registry.
     get_record_class = function() {
       private$.record_class

--- a/R/UserSettings.R
+++ b/R/UserSettings.R
@@ -30,6 +30,16 @@ UserSettings <- R6::R6Class( # nolint object_name_linter
         cli_abort("Unexpected column: ", unexpected_columns)
       }
       private$.settings <- settings
+    },
+    print = function(style = TRUE) {
+      cli::cat_line(self$to_string(style))
+    },
+
+    to_string = function(style = FALSE)  {
+
+      field_strings <- make_key_value_strings(private$.settings)
+
+      make_class_string("UserSettings", field_strings, style = style)
     }
   ),
   private = list(

--- a/R/UserSettings.R
+++ b/R/UserSettings.R
@@ -31,12 +31,20 @@ UserSettings <- R6::R6Class( # nolint object_name_linter
       }
       private$.settings <- settings
     },
+    #' @description
+    #' Print a `UserSettings`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
     print = function(style = TRUE) {
       cli::cat_line(self$to_string(style))
     },
-
-    to_string = function(style = FALSE)  {
-
+    #' @description
+    #' Create a string representation of a `UserSettings`
+    #'
+    #' @param style Logical, whether the output is styled using ANSI codes
+    #'
+    #' @return A `cli::cli_ansi_string` if `style = TRUE` or a character vector
+    to_string = function(style = FALSE) {
       field_strings <- make_key_value_strings(private$.settings)
 
       make_class_string("UserSettings", field_strings, style = style)

--- a/R/printing.R
+++ b/R/printing.R
@@ -7,10 +7,11 @@
 #'   `mapping[[name]]`
 #' @param names Vector of names to create strings for. Defaults to all names of
 #'   `mapping`
+#' @param quote_strings Logical, whether to quote string values
 #'
 #' @return A vector of `cli::cli_ansi_string` objects
 #' @noRd
-make_key_value_strings <- function(mapping, names = NULL) {
+make_key_value_strings <- function(mapping, names = NULL, quote_strings = TRUE) {
 
     if (is.null(names)) {
         names <- names(mapping)
@@ -23,7 +24,7 @@ make_key_value_strings <- function(mapping, names = NULL) {
           return(NA_character_)
         }
 
-        if (is.character(value)) {
+        if (quote_strings && is.character(value)) {
             value <- paste0("'", value, "'")
         }
 

--- a/R/printing.R
+++ b/R/printing.R
@@ -12,34 +12,33 @@
 #' @return A vector of `cli::cli_ansi_string` objects
 #' @noRd
 make_key_value_strings <- function(mapping, names = NULL, quote_strings = TRUE) {
+  if (is.null(names)) {
+    names <- names(mapping)
+  }
 
-    if (is.null(names)) {
-        names <- names(mapping)
+  purrr::map_chr(names, function(.name) {
+    value <- mapping[[.name]]
+
+    if (is.null(value)) {
+      return(NA_character_)
     }
 
-    purrr::map_chr(names, function(.name) {
-        value <- mapping[[.name]]
+    if (quote_strings && is.character(value)) {
+      value <- paste0("'", value, "'")
+    }
 
-        if (is.null(value)) {
-          return(NA_character_)
-        }
+    if (is.list(value)) {
+      list_strings <- make_key_value_strings(value)
+      value <- paste0(
+        "list(", cli::ansi_strip(paste(list_strings, collapse = ", ")), ")"
+      )
+    }
 
-        if (quote_strings && is.character(value)) {
-            value <- paste0("'", value, "'")
-        }
-
-        if (is.list(value)) {
-          list_strings <- make_key_value_strings(value)
-          value <- paste0(
-            "list(", cli::ansi_strip(paste(list_strings, collapse = ", ")), ")"
-          )
-        }
-
-        paste0(
-            cli::col_blue(.name), cli::col_br_blue("="), cli::col_yellow(value)
-        )
-    }) |>
-        purrr::discard(is.na)
+    paste0(
+      cli::col_blue(.name), cli::col_br_blue("="), cli::col_yellow(value)
+    )
+  }) |>
+    purrr::discard(is.na)
 }
 
 #' Make a string representation of a class
@@ -53,15 +52,15 @@ make_key_value_strings <- function(mapping, names = NULL, quote_strings = TRUE) 
 #'   character vector
 #' @noRd
 make_class_string <- function(class_name, field_strings, style = TRUE) {
-    string <- paste0(
-        cli::style_bold(cli::col_green(class_name)), "(",
-        paste(field_strings, collapse = ", "),
-        ")"
-    )
+  string <- paste0(
+    cli::style_bold(cli::col_green(class_name)), "(",
+    paste(field_strings, collapse = ", "),
+    ")"
+  )
 
-    if (isFALSE(style)) {
-        string <- cli::ansi_strip(string)
-    }
+  if (isFALSE(style)) {
+    string <- cli::ansi_strip(string)
+  }
 
-    return(string)
+  return(string)
 }

--- a/R/printing.R
+++ b/R/printing.R
@@ -20,11 +20,18 @@ make_key_value_strings <- function(mapping, names = NULL) {
         value <- mapping[[.name]]
 
         if (is.null(value)) {
-            return(NA_character_)
+          return(NA_character_)
         }
 
         if (is.character(value)) {
             value <- paste0("'", value, "'")
+        }
+
+        if (is.list(value)) {
+          list_strings <- make_key_value_strings(value)
+          value <- paste0(
+            "list(", cli::ansi_strip(paste(list_strings, collapse = ", ")), ")"
+          )
         }
 
         paste0(

--- a/R/printing.R
+++ b/R/printing.R
@@ -1,0 +1,59 @@
+#' Make key value strings
+#'
+#' Generate a vector of styled strings representing key-value pairs. Any
+#' `NULL`/`NA` values are not returned.
+#'
+#' @param mapping Any object for which values can be retrieved using names with
+#'   `mapping[[name]]`
+#' @param names Vector of names to create strings for. Defaults to all names of
+#'   `mapping`
+#'
+#' @return A vector of `cli::cli_ansi_string` objects
+#' @noRd
+make_key_value_strings <- function(mapping, names = NULL) {
+
+    if (is.null(names)) {
+        names <- names(mapping)
+    }
+
+    purrr::map_chr(names, function(.name) {
+        value <- mapping[[.name]]
+
+        if (is.null(value)) {
+            return(NA_character_)
+        }
+
+        if (is.character(value)) {
+            value <- paste0("'", value, "'")
+        }
+
+        paste0(
+            cli::col_blue(.name), cli::col_br_blue("="), cli::col_yellow(value)
+        )
+    }) |>
+        purrr::discard(is.na)
+}
+
+#' Make a string representation of a class
+#'
+#' @param class_name Name of the class
+#' @param field_strings A vector of formatted name strings as produced by
+#'   `make_key_value_strings`
+#' @param style Whether or not to returned a styled string
+#'
+#' @return A `cli::cli_ansi_string` object if `style = TRUE`, otherwise a
+#'   character vector
+#' @noRd
+make_class_string <- function(class_name, field_strings, style = TRUE) {
+    string <- paste0(
+        cli::style_bold(cli::col_green(class_name)), "(",
+        paste(field_strings, collapse = ", "),
+        ")"
+    )
+
+    if (isFALSE(style)) {
+        string <- cli::ansi_strip(string)
+    }
+
+    return(string)
+}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ artifact <- db$Artifact$get("KBW89Mf7IGcekja2hADu")
 artifact
 ```
 
-    Artifact(uid='KBW89Mf7IGcekja2hADu', description='Myeloid compartment', key='cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad', version='2024-07-01', _accessor='AnnData', id=3659, transform_id=22, size=691757462, is_latest=TRUE, created_by_id=1, _hash_type='md5-n', type='dataset', created_at='2024-07-12T12:34:10.345829+00:00', n_observations=51552, updated_at='2024-07-12T12:40:48.837026+00:00', run_id=27, suffix='.h5ad', visibility=1, _key_is_virtual=FALSE, hash='SZ5tB0T4YKfiUuUkAL09ZA', storage_id=2)
+    Artifact(uid='KBW89Mf7IGcekja2hADu', description='Myeloid compartment', key='cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad', suffix='.h5ad', type='dataset', size=691757462, hash='SZ5tB0T4YKfiUuUkAL09ZA', n_observations=51552, visibility=1, version='2024-07-01', is_latest=TRUE, created_at='2024-07-12T12:34:10.345829+00:00', updated_at='2024-07-12T12:40:48.837026+00:00', created_by_id=1, storage_id=2, transform_id=22, run_id=27, _accessor='AnnData', _hash_type='md5-n', _key_is_virtual=FALSE, id=3659)
 
 Access some of its fields:
 
@@ -93,7 +93,7 @@ Load the artifact:
 artifact$load()
 ```
 
-    ℹ 's3://cellxgene-data-public/cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad' already exists at '/home/rcannood/.cache/lamindb/cellxgene-data-public/cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad'
+    ℹ 's3://cellxgene-data-public/cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad' already exists at '/home/luke/.cache/lamindb/cellxgene-data-public/cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad'
 
     AnnData object with n_obs × n_vars = 51552 × 36398
         obs: 'donor_id', 'Predicted_labels_CellTypist', 'Majority_voting_CellTypist', 'Manually_curated_celltype', 'assay_ontology_term_id', 'cell_type_ontology_term_id', 'development_stage_ontology_term_id', 'disease_ontology_term_id', 'self_reported_ethnicity_ontology_term_id', 'is_primary_data', 'organism_ontology_term_id', 'sex_ontology_term_id', 'tissue_ontology_term_id', 'suspension_type', 'tissue_type', 'cell_type', 'assay', 'disease', 'organism', 'sex', 'tissue', 'self_reported_ethnicity', 'development_stage', 'observation_joinid'


### PR DESCRIPTION
Add `print()` and `to_string()` methods to the remaining R6 classes. Output tries to replicate the Python formatting except for some cases where the corresponding Python object doesn't have a print output.