### PR TITLE
Add get_records() to API and df() to Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
 * Auto-generate modules and classes from the instance schema
 * Fetch a record
 * Fetch a record's related data
+* Fetch record summary table
 * Cache S3 artifact
 * Load AnnData artifact
 
@@ -22,6 +23,8 @@ For more information, please visit the [package website](https://laminr.lamin.ai
 * Add `to_string()` and `print()` methods to the `Record` class and (incomplete) `describe()` method to the `Artifact()` class (PR #22).
 
 * Add `to_string()` and `print()` methods to remaining classes (PR #31)
+
+* Add `InstanceAPI$get_records()` and `Registry$df()` methods (PR #54)
 
 ## MAJOR CHANGES
 

--- a/R/InstanceAPI.R
+++ b/R/InstanceAPI.R
@@ -117,7 +117,8 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
     #' @param search Search string included in the query body
     #' @param verbose Boolean, whether to print progress messages
     #'
-    #' @return Content of the API response
+    #' @return Content of the API response, if successful a list of record
+    #' summaries
     #'
     #' @importFrom jsonlite toJSON
     get_records = function(module_name,

--- a/R/InstanceAPI.R
+++ b/R/InstanceAPI.R
@@ -112,7 +112,7 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
     #' @param registry_name Name of the registry to query
     #' @param limit Maximum number of records to return
     #' @param offset Offset for the first returned record
-    #' @param limit_to_many
+    #' @param limit_to_many Maximum number of related foreign fields to return
     #' @param include_foreign_keys Boolean, whether to return foreign keys
     #' @param search Search string included in the query body
     #' @param verbose Boolean, whether to print progress messages

--- a/R/InstanceAPI.R
+++ b/R/InstanceAPI.R
@@ -89,6 +89,98 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
         tolower(include_foreign_keys)
       )
 
+      if (verbose) {
+        cli_inform("URL: {url}")
+        cli_inform("Body: {jsonlite::minify(body)}")
+      }
+
+      response <- httr::POST(
+        url,
+        httr::add_headers(
+          accept = "application/json",
+          `Content-Type` = "application/json"
+        ),
+        body = body
+      )
+
+      private$process_response(response, "get record")
+    },
+    #' @description
+    #' Get a summary of available records from the instance.
+    #'
+    #' @param module_name Name of the module to query, e.g. "core"
+    #' @param registry_name Name of the registry to query
+    #' @param limit Maximum number of records to return
+    #' @param offset Offset for the first returned record
+    #' @param limit_to_many
+    #' @param include_foreign_keys Boolean, whether to return foreign keys
+    #' @param search Search string included in the query body
+    #' @param verbose Boolean, whether to print progress messages
+    #'
+    #' @return Content of the API response
+    #'
+    #' @importFrom jsonlite toJSON
+    get_records = function(module_name,
+                           registry_name,
+                           limit = 50,
+                           offset = 0,
+                           limit_to_many = 10,
+                           include_foreign_keys = FALSE,
+                           search = NULL,
+                           verbose = FALSE) {
+      if (!is.null(search) && !is.character(search)) {
+        cli_abort("search must be a character vector")
+      }
+
+      if (limit > 200) {
+        cli::cli_abort("This API call is limited to 200 results per call")
+      }
+
+      if (verbose) {
+        cli_inform(c(
+          paste0(
+            "Getting records from module '", module_name, "', ",
+            "registry '", registry_name, "' with the following arguments:"
+          ),
+          " " = "limit: {limit}",
+          " " = "offset: {offset}",
+          " " = "limit_to_many: {limit_to_many}",
+          " " = "include_foreign_keys: {include_foreign_keys}",
+          " " = "search: '{search}'"
+        ))
+      }
+
+      body_data <- list(search = jsonlite::unbox(""))
+      if (!is.null(search)) {
+        body_data$search <- jsonlite::unbox(search)
+      }
+      body <- jsonlite::toJSON(body_data)
+
+      url <- paste0(
+        private$.instance_settings$api_url,
+        "/instances/",
+        private$.instance_settings$id,
+        "/modules/",
+        module_name,
+        "/",
+        registry_name,
+        "?schema_id=",
+        private$.instance_settings$schema_id,
+        "&limit=",
+        limit,
+        "&offset=",
+        offset,
+        "&limit_to_many=",
+        limit_to_many,
+        "&include_foreign_keys=",
+        tolower(include_foreign_keys)
+      )
+
+      if (verbose) {
+        cli_inform("URL: {url}")
+        cli_inform("Body: {jsonlite::minify(body)}")
+      }
+
       response <- httr::POST(
         url,
         httr::add_headers(

--- a/R/Registry.R
+++ b/R/Registry.R
@@ -117,9 +117,10 @@ Registry <- R6::R6Class( # nolint object_name_linter
           # If not the final request and less than 200 records returned then
           # there are no more records and we can skip remaining requests
           if ((.n != n_requests) && length(.data_list) < 200) {
-            cli::cli_alert_info(
-              "Found all records. Stopping early with {length(.data_list)} record{?s} after {(.n)} request{?s}."
-            )
+            cli::cli_alert_info(paste(
+              "Found all records. Stopping early with {length(.data_list)}",
+              "record{?s} after {(.n)} request{?s}."
+            ))
             attr(.data_list, "finished") <- TRUE
           }
 

--- a/R/Registry.R
+++ b/R/Registry.R
@@ -77,7 +77,6 @@ Registry <- R6::R6Class( # nolint object_name_linter
     #'
     #' @return A data.frame containing the available records
     df = function(limit = 100, verbose = FALSE) {
-
       # The API is limited to 200 records at a time so we need multiple requests
       n_requests <- ceiling(limit / 200)
       if ((verbose && n_requests > 1) || n_requests >= 10) {
@@ -92,14 +91,13 @@ Registry <- R6::R6Class( # nolint object_name_linter
       data_list <- purrr::reduce(
         cli::cli_progress_along(seq_len(n_requests), name = "Sending requests"),
         \(.data_list, .n) {
-
           # Hacky way of avoiding unneeded requests until there is an easy way
           # to get the total number of records
           if (isTRUE(attr(.data_list, "finished"))) {
             return(.data_list)
           }
 
-          offset = (.n - 1) * 200
+          offset <- (.n - 1) * 200
           # Reduce limit for final request to get the correct total
           current_limit <- ifelse(.n == n_requests, limit %% 200, 200)
           if (verbose) {

--- a/R/Registry.R
+++ b/R/Registry.R
@@ -70,6 +70,75 @@ Registry <- R6::R6Class( # nolint object_name_linter
       private$.record_class$new(data = data)
     },
     #' @description
+    #' Get a data frame summarising records in the registry
+    #'
+    #' @param limit Maximum number of records to return
+    #' @param verbose Boolean, whether to print progress messages
+    #'
+    #' @return A data.frame containing the available records
+    df = function(limit = 100, verbose = FALSE) {
+
+      # The API is limited to 200 records at a time so we need multiple requests
+      n_requests <- ceiling(limit / 200)
+      if ((verbose && n_requests > 1) || n_requests >= 10) {
+        caution <- ifelse(n_requests >= 10, "CAUTION: ", "")
+        cli::cli_alert_warning(
+          "{caution}Retrieving {limit} records will require up to {n_requests} API requests"
+        )
+      }
+
+      data_list <- list()
+      attr(data_list, "finished") <- FALSE
+      data_list <- purrr::reduce(
+        cli::cli_progress_along(seq_len(n_requests), name = "Sending requests"),
+        \(.data_list, .n) {
+
+          # Hacky way of avoiding unneeded requests until there is an easy way
+          # to get the total number of records
+          if (isTRUE(attr(.data_list, "finished"))) {
+            return(.data_list)
+          }
+
+          offset = (.n - 1) * 200
+          # Reduce limit for final request to get the correct total
+          current_limit <- ifelse(.n == n_requests, limit %% 200, 200)
+          if (verbose) {
+            cli::cli_alert_info(
+              "Requesting records {offset} to {offset + current_limit}..."
+            )
+          }
+          current_data <- private$.api$get_records(
+            module_name = private$.module$name,
+            registry_name = private$.registry_name,
+            limit = current_limit,
+            offset = offset,
+            verbose = verbose
+          )
+
+          .data_list <- c(.data_list, current_data)
+          # If not the final request and less than 200 records returned then
+          # there are no more records and we can skip remaining requests
+          if ((.n != n_requests) && length(.data_list) < 200) {
+            cli::cli_alert_info(
+              "Found all records. Stopping early with {length(.data_list)} record{?s} after {(.n)} request{?s}."
+            )
+            attr(.data_list, "finished") <- TRUE
+          }
+
+          return(.data_list)
+        },
+        .init = data_list
+      )
+
+      data_list |>
+        # Replace NULL with NA so columns aren't lost
+        purrr::modify_depth(2, \(x) ifelse(is.null(x), NA, x)) |>
+        # Convert each entry to a data.frame
+        purrr::map(as.data.frame) |>
+        # Bind entries as rows
+        purrr::list_rbind()
+    },
+    #' @description
     #' Get the fields in the registry.
     #'
     #' @return A list of [Field] objects.

--- a/man/Registry.Rd
+++ b/man/Registry.Rd
@@ -28,6 +28,7 @@ Whether the registry is a link table.}
 \itemize{
 \item \href{#method-Registry-new}{\code{Registry$new()}}
 \item \href{#method-Registry-get}{\code{Registry$get()}}
+\item \href{#method-Registry-df}{\code{Registry$df()}}
 \item \href{#method-Registry-get_fields}{\code{Registry$get_fields()}}
 \item \href{#method-Registry-get_field}{\code{Registry$get_field()}}
 \item \href{#method-Registry-get_field_names}{\code{Registry$get_field_names()}}
@@ -84,6 +85,28 @@ Get a record by ID or UID.
 }
 \subsection{Returns}{
 A \link{Record} object.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Registry-df"></a>}}
+\if{latex}{\out{\hypertarget{method-Registry-df}{}}}
+\subsection{Method \code{df()}}{
+Get a data frame summarising records in the registry
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Registry$df(limit = 100, verbose = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{limit}}{Maximum number of records to return}
+
+\item{\code{verbose}}{Boolean, whether to print progress messages}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+A data.frame containing the available records
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/laminr-package.Rd
+++ b/man/laminr-package.Rd
@@ -23,6 +23,7 @@ Useful links:
 Authors:
 \itemize{
   \item Luke Zappia \email{luke@data-intuitive.com} (\href{https://orcid.org/0000-0001-7744-8565}{ORCID}) (lazappi)
+  \item Data Intuitive \email{info@data-intuitive.com}
   \item Lamin Labs \email{open-source@lamin.ai} [copyright holder]
 }
 

--- a/tests/testthat/test-Registry.R
+++ b/tests/testthat/test-Registry.R
@@ -1,3 +1,5 @@
+skip_if_offline()
+
 test_that("df works", {
   local_setup_lamindata_instance()
 

--- a/tests/testthat/test-Registry.R
+++ b/tests/testthat/test-Registry.R
@@ -1,0 +1,10 @@
+test_that("df works", {
+  local_setup_lamindata_instance()
+
+  db <- connect("laminlabs/lamindata")
+
+  records <- db$Storage$df()
+
+  expect_s3_class(records, "data.frame")
+  expect_true(all(c("description", "created_at", "id", "uid") %in% colnames(records)))
+})

--- a/tests/testthat/test-instance_api.R
+++ b/tests/testthat/test-instance_api.R
@@ -104,8 +104,7 @@ test_that("get_record fails gracefully", {
   # nolint end: commented_code
 })
 
-test_that("get_records workds", {
-
+test_that("get_records works", {
   local_setup_lamindata_instance()
 
   instance_file <- .settings_store__instance_settings_file("laminlabs", "lamindata")
@@ -118,5 +117,4 @@ test_that("get_records workds", {
   expect_type(records, "list")
   expect_type(records[[1]], "list")
   expect_true(all(c("description", "created_at", "id", "uid") %in% names(records[[1]])))
-
 })

--- a/tests/testthat/test-instance_api.R
+++ b/tests/testthat/test-instance_api.R
@@ -103,3 +103,20 @@ test_that("get_record fails gracefully", {
   )
   # nolint end: commented_code
 })
+
+test_that("get_records workds", {
+
+  local_setup_lamindata_instance()
+
+  instance_file <- .settings_store__instance_settings_file("laminlabs", "lamindata")
+  instance_settings <- .settings_load__load_instance_settings()
+
+  api <- InstanceAPI$new(instance_settings)
+
+  records <- api$get_records("core", "storage")
+
+  expect_type(records, "list")
+  expect_type(records[[1]], "list")
+  expect_true(all(c("description", "created_at", "id", "uid") %in% names(records[[1]])))
+
+})


### PR DESCRIPTION
Adds a `get_records()` method to the `InstanceAPI` class which performs the API call to retrieve record summary information and a `df()` method to the `Registry` class which makes the required API calls to get the requested number of records and formats the returned information as a `data.frame()`. This tries to be semi-smart to limit the number of API calls.

Fixes #43 

Checks:

- [x] CI runs
- [ ] Update `CHANGELOG`