### PR TITLE
Remove link tables from print output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ For more information, please visit the [package website](https://laminr.lamin.ai
 
 * Define a current user and current instance with lamin-cli prior to testing and generating documentation in the CI (PR #23).
 
+* Remove link tables for object print output (PR #55)
+
 ## TESTING
 
 * Add a simple unit test which queries laminlabs/lamindata (PR #27).

--- a/R/Instance.R
+++ b/R/Instance.R
@@ -175,19 +175,10 @@ Instance <- R6::R6Class( # nolint object_name_linter
         }
       )
 
-      link_lines <- purrr::map_chr(
-        names(registries)[is_link_table],
-        function(.registry) {
-          cli::col_blue(paste0("    ", .registry))
-        }
-      )
-
       lines <- c(
         cli::style_bold(cli::col_green(private$.settings$name)),
         cli::style_italic(cli::col_magenta("  Core registries")),
-        standard_lines,
-        cli::style_italic(cli::col_magenta("  Core link tables")),
-        link_lines
+        standard_lines
       )
 
       module_names <- self$get_module_names()
@@ -229,11 +220,6 @@ Instance <- R6::R6Class( # nolint object_name_linter
             ),
             collapse = ", "
           ),
-          "]"
-        ),
-        "CoreLinkTables" = paste0(
-          "[",
-          paste(names(registries[is_link_table]), collapse = ", "),
           "]"
         )
       )

--- a/R/Module.R
+++ b/R/Module.R
@@ -113,19 +113,10 @@ Module <- R6::R6Class( # nolint object_name_linter
         }
       )
 
-      link_lines <- purrr::map_chr(
-        names(registries)[is_link_table],
-        function(.registry) {
-          cli::col_blue(paste0("    ", .registry))
-        }
-      )
-
       lines <- c(
         cli::style_bold(cli::col_green(private$.module_name)),
         cli::style_italic(cli::col_magenta("  Registries")),
-        standard_lines,
-        cli::style_italic(cli::col_magenta("  Link tables")),
-        link_lines
+        standard_lines
       )
 
       if (isFALSE(style)) {
@@ -157,11 +148,6 @@ Module <- R6::R6Class( # nolint object_name_linter
               ),
               collapse = ", "
             ),
-            "]"
-          ),
-          "LinkTables" = paste0(
-            "[",
-            paste(names(registries[is_link_table]), collapse = ", "),
             "]"
           )
         ),

--- a/README.md
+++ b/README.md
@@ -64,15 +64,6 @@ db
         $FeatureSet
         $ParamValue
         $FeatureValue
-      Core link tables
-        runparamvalue
-        artifactulabel
-        collectionulabel
-        featuresetfeature
-        artifactfeatureset
-        artifactparamvalue
-        collectionartifact
-        artifactfeaturevalue
       Additional modules
         bionty
 
@@ -90,7 +81,7 @@ You can print the record:
 artifact
 ```
 
-    Artifact(uid='KBW89Mf7IGcekja2hADu', description='Myeloid compartment', key='cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad', storage_id=2, _accessor='AnnData', version='2024-07-01', id=3659, size=691757462, transform_id=22, is_latest=TRUE, type='dataset', n_observations=51552, created_by_id=1, _hash_type='md5-n', created_at='2024-07-12T12:34:10.345829+00:00', suffix='.h5ad', updated_at='2024-07-12T12:40:48.837026+00:00', _key_is_virtual=FALSE, visibility=1, run_id=27, hash='SZ5tB0T4YKfiUuUkAL09ZA')
+    Artifact(uid='KBW89Mf7IGcekja2hADu', description='Myeloid compartment', key='cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad', created_by_id=1, run_id=27, suffix='.h5ad', created_at='2024-07-12T12:34:10.345829+00:00', hash='SZ5tB0T4YKfiUuUkAL09ZA', _hash_type='md5-n', storage_id=2, version='2024-07-01', _accessor='AnnData', id=3659, is_latest=TRUE, _key_is_virtual=FALSE, transform_id=22, n_observations=51552, size=691757462, visibility=1, updated_at='2024-07-12T12:40:48.837026+00:00', type='dataset')
 
 Or call the `$describe()` method to get a summary:
 
@@ -98,7 +89,7 @@ Or call the `$describe()` method to get a summary:
 artifact$describe()
 ```
 
-    Artifact(uid='KBW89Mf7IGcekja2hADu', description='Myeloid compartment', key='cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad', storage_id=2, _accessor='AnnData', version='2024-07-01', id=3659, size=691757462, transform_id=22, is_latest=TRUE, type='dataset', n_observations=51552, created_by_id=1, _hash_type='md5-n', created_at='2024-07-12T12:34:10.345829+00:00', suffix='.h5ad', updated_at='2024-07-12T12:40:48.837026+00:00', _key_is_virtual=FALSE, visibility=1, run_id=27, hash='SZ5tB0T4YKfiUuUkAL09ZA')
+    Artifact(uid='KBW89Mf7IGcekja2hADu', description='Myeloid compartment', key='cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad', created_by_id=1, run_id=27, suffix='.h5ad', created_at='2024-07-12T12:34:10.345829+00:00', hash='SZ5tB0T4YKfiUuUkAL09ZA', _hash_type='md5-n', storage_id=2, version='2024-07-01', _accessor='AnnData', id=3659, is_latest=TRUE, _key_is_virtual=FALSE, transform_id=22, n_observations=51552, size=691757462, visibility=1, updated_at='2024-07-12T12:40:48.837026+00:00', type='dataset')
       Provenance
         $storage = 's3://cellxgene-data-public'
         $transform = 'Census release 2024-07-01 (LTS)'
@@ -127,7 +118,7 @@ You can directly load the artifact to access its data:
 artifact$load()
 ```
 
-    ℹ 's3://cellxgene-data-public/cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad' already exists at '/home/rcannood/.cache/lamindb/cellxgene-data-public/cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad'
+    ℹ 's3://cellxgene-data-public/cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad' already exists at '/home/luke/.cache/lamindb/cellxgene-data-public/cell-census/2024-07-01/h5ads/fe52003e-1460-4a65-a213-2bb1a508332f.h5ad'
 
     AnnData object with n_obs × n_vars = 51552 × 36398
         obs: 'donor_id', 'Predicted_labels_CellTypist', 'Majority_voting_CellTypist', 'Manually_curated_celltype', 'assay_ontology_term_id', 'cell_type_ontology_term_id', 'development_stage_ontology_term_id', 'disease_ontology_term_id', 'self_reported_ethnicity_ontology_term_id', 'is_primary_data', 'organism_ontology_term_id', 'sex_ontology_term_id', 'tissue_ontology_term_id', 'suspension_type', 'tissue_type', 'cell_type', 'assay', 'disease', 'organism', 'sex', 'tissue', 'self_reported_ethnicity', 'development_stage', 'observation_joinid'


### PR DESCRIPTION
Remove link tables from the print output for `Instance` and `Module` classes.

Fixes #52 