### PR TITLE
try using experimental quarto to see whether it solves ci issue

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: 1.6.30
+
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-tinytex@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: v1.6.30
+          version: 1.6.30
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -31,6 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: v1.6.30
+
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ For more information, please visit the [package website](https://laminr.lamin.ai
 * Set Python requirements to `lamindb[aws]` for now (PR #33). Will be changed to `lamin_cli` once 
   [laminlabs/lamin-cli#90](https://github.com/laminlabs/lamin-cli/issues/90) is solved.
 
+* Use quarto 1.6 for rendering the vignettes (PR #60).
+
 ## BUG FIXES
 
 * Fixed the parsing of the env files in `~/.lamin` due to changes in the lamindb-setup Python package (PR #12).

--- a/vignettes/usage.qmd
+++ b/vignettes/usage.qmd
@@ -3,7 +3,7 @@ title: "Usage"
 vignette: >
   %\VignetteIndexEntry{Usage}
   %\VignetteEncoding{UTF-8}
-  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEngine{quarto::html}
 knitr:
   opts_chunk: 
     collapse: true

--- a/vignettes/usage.qmd
+++ b/vignettes/usage.qmd
@@ -1,18 +1,14 @@
 ---
 title: "Usage"
-output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Usage}
   %\VignetteEncoding{UTF-8}
   %\VignetteEngine{knitr::rmarkdown}
+knitr:
+  opts_chunk: 
+    collapse: true
+    comment: "#>"
 ---
-
-```{r, include = FALSE}
-knitr::opts_chunk$set(
-  collapse = TRUE,
-  comment = "#>"
-)
-```
 
 LaminDB is an open-source data framework for biology. You can find out about some of its features in the [documentation of the lamindb Python package](https://docs.lamin.ai/introduction).
 


### PR DESCRIPTION
This PR switches the usage.qmd vignette back to Quarto.

On CRAN win devel this also works, except that the vignette is not rendering on CRAN because lamin_cli is not installed. I created a separate issue for this → #61
