### PR TITLE
Improve API error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,11 +51,15 @@ For more information, please visit the [package website](https://laminr.lamin.ai
 
 * Improve checking for suggested packages and provide installation instructions if missing (PR #56)
 
+* Add the status code to API error messages (PR #70)
+
 ## TESTING
 
 * Add a simple unit test which queries laminlabs/lamindata (PR #27).
 
 * Added unit test for the InstanceAPI class (PR #30).
+
+* Add a regular expression to the API test for missing records (PR #70)
 
 ## DOCUMENTATION
 

--- a/R/InstanceAPI.R
+++ b/R/InstanceAPI.R
@@ -231,7 +231,7 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
           detail <- content
         }
         cli_abort(c(
-          "Failed to {request_type} from instance",
+          "Failed to {request_type} from instance with status code {response$status_code}",
           "i" = "Details: {detail}"
         ))
       }

--- a/tests/testthat/test-instance_api.R
+++ b/tests/testthat/test-instance_api.R
@@ -91,12 +91,13 @@ test_that("get_record fails gracefully", {
 
   api <- InstanceAPI$new(instance_settings)
 
+  expect_error(
+    api$get_record("core", "artifact", "foobar"),
+    regexp = "404: Record not found"
+  )
+
   # nolint start: commented_code
   # TODO: improve error messages for these cases
-  expect_error(
-    api$get_record("core", "artifact", "foobar") # ,
-    # regexp = "Error getting record: list index out of range"
-  )
   expect_error(
     api$get_record("core", "artifact", "mePviem4DGM4SFzvLXf3", select = "foo"),
     # regexp = "Error getting record: invalid select field: foo"


### PR DESCRIPTION
Add the status code to the API error message and update the test for when records don't exist

Fixes #44 