### PR TITLE
Fix Mermid diagrams in vignettes

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -39,6 +39,7 @@ jobs:
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
+          quarto-version: pre-release
 
       - name: Install lamindb
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -57,6 +57,12 @@ jobs:
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
+      - name: Create built site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkgdown-site
+          path: docs
+
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
**Related to:** Fixes #91 

## Description

Use the pre-release version of Quarto in the `pkgdown` workflow so the architecture diagrams are rendered correctly.

## Checklist

**Before review**

- [ ] ~Update and regenerate man pages~
- [ ] ~Add/update tests~
- [ ] ~Add/update examples in vignettes~
- [x] Pass CI checks

**Before merge**

- [ ] Update architecture vignette
- [ ] ~Update development vignette~
- [ ] ~Update features in `README`~
- [ ] Update `CHANGELOG`
