### PR TITLE
Automatically detect paths for tracking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     httr,
     jsonlite,
     purrr,
+    R.utils,
     R6,
     rlang,
     tibble

--- a/R/Instance.R
+++ b/R/Instance.R
@@ -225,7 +225,12 @@ Instance <- R6::R6Class( # nolint object_name_linter
       py_lamin <- self$get_py_lamin(check = TRUE, what = "Tracking")
 
       if (is.null(path)) {
-        cli::cli_abort("The {.arg path} argument must be provided")
+        path <- detect_path()
+        if (is.null(path)) {
+          cli::cli_abort(
+            "Failed to detect the path to track. Please set the {.arg path} argument."
+          )
+        }
       }
 
       if (is.null(transform)) {


### PR DESCRIPTION
**Related to:** Fixes #115 

## Description

- Add a `detect_path()` function
- Use this function in `Instance$track()` to attempt to detect which path to track

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update architecture vignette
- [ ] Update development vignette
- [ ] Update features in `README`
- [ ] Update `CHANGELOG`
