### PR TITLE
🐛 Fix error message when fetching the instance details fails

### DIFF
--- a/R/InstanceAPI.R
+++ b/R/InstanceAPI.R
@@ -36,7 +36,7 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
         httr::add_headers(.headers = private$get_headers())
       )
 
-      private$process_response(response, "get schema")
+      process_httr_response(response, "get schema from instance")
     },
     #' @description
     #' Get a record from the instance.
@@ -106,7 +106,7 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
         body = body
       )
 
-      private$process_response(response, "get record")
+      process_httr_response(response, "get record from instance")
     },
     #' @description
     #' Get a summary of available records from the instance.
@@ -191,7 +191,7 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
         body = body
       )
 
-      private$process_response(response, "get record")
+      process_httr_response(response, "get record from instance")
     },
     #' @description
     #' Delete a record from the instance.
@@ -224,7 +224,7 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
         )
       )
 
-      private$process_response(response, "delete record")
+      process_httr_response(response, "delete record from instance")
     },
     #' @description
     #' Print an `API`
@@ -266,25 +266,6 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
       }
 
       return(headers)
-    },
-    process_response = function(response, request_type) {
-      content <- httr::content(response)
-      if (httr::http_error(response)) {
-        if (is.list(content) && "detail" %in% names(content)) {
-          detail <- content$detail
-          if (is.list(detail)) {
-            detail <- jsonlite::minify(jsonlite::toJSON(content$detail))
-          }
-        } else {
-          detail <- content
-        }
-        cli_abort(c(
-          "Failed to {request_type} from instance with status code {response$status_code}",
-          "i" = "Details: {detail}"
-        ))
-      }
-
-      content
     }
   )
 )

--- a/R/connect.R
+++ b/R/connect.R
@@ -158,11 +158,8 @@ connect <- function(slug = NULL) {
     ),
     body = body
   )
-  content <- httr::content(request)
+  content <- process_httr_response(request, "connect to instance")
 
-  if (httr::http_error(request)) {
-    cli_abort(content)
-  }
   if (length(content) == 0) {
     cli_abort(paste0("Instance '", owner, "/", name, "' not found"))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -102,3 +102,30 @@ detect_path <- function() {
 
   return(current_path)
 }
+
+#' Resolve an httr response with error handling
+#'
+#' @param response An httr response object
+#' @param request_type A string describing the request type
+#'
+#' @return The content of the response if successful
+#' @noRd
+process_httr_response <- function(response, request_type) {
+  content <- httr::content(response)
+  if (httr::http_error(response)) {
+    if (is.list(content) && "detail" %in% names(content)) {
+      detail <- content$detail
+      if (is.list(detail)) {
+        detail <- jsonlite::minify(jsonlite::toJSON(content$detail))
+      }
+    } else {
+      detail <- content
+    }
+    cli_abort(c(
+      "Failed to {request_type} with status code {response$status_code}",
+      "i" = "Details: {detail}"
+    ))
+  }
+
+  content
+}


### PR DESCRIPTION
**Related to:** <!-- Add links to related issues etc. here -->

## Description

My JWT token expired, but trying to connect to an instance resulted in the following error:

```r
> devtools::install()
> library(laminr)
> db <- connect("laminlabs/cellxgene")
db$Artifact
Error in `rlang::abort()`:
! `message` must be a character vector, not a list.
Run `rlang::last_trace()` to see where the error occurred.
```

## Checklist

**Before review**

- [x] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update architecture vignette
- [ ] Update development vignette
- [ ] Update features in `README`
- [ ] Update `CHANGELOG`
