### PR TITLE
✨ Tracking artifacts loaded from other instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # laminr v0.2.1
 
+## NEW FUNCTIONALITY
+
+- Allow tracking of artifacts loaded for non-default instances (PR #124)
+
 ## BUG FIXES
 
 - Allow connecting to private LaminDB instances (PR #118)

--- a/R/Artifact.R
+++ b/R/Artifact.R
@@ -27,6 +27,18 @@ ArtifactRecord <- R6::R6Class( # nolint object_name_linter
     #'
     #' @return The path to the cached artifact
     cache = function() {
+
+      py_lamin <- private$.instance$get_py_lamin()
+      if (!is.null(py_lamin)) {
+        py_artifact <- py_lamin$Artifact$get(self$uid)
+        return(py_artifact$cache()$path)
+      }
+
+      cli::cli_warn(paste(
+        "The Python {.pkg lamindb} package is not available.",
+        "Loaded artifacts will not be tracked."
+      ))
+
       # assume that an artifact will have a storage field,
       # and that the storage field will have a type field
       artifact_storage <- private$get_value("storage")

--- a/R/Artifact.R
+++ b/R/Artifact.R
@@ -30,7 +30,14 @@ ArtifactRecord <- R6::R6Class( # nolint object_name_linter
 
       py_lamin <- private$.instance$get_py_lamin()
       if (!is.null(py_lamin)) {
-        py_artifact <- py_lamin$Artifact$get(self$uid)
+        if (isTRUE(private$.instance$is_default)) {
+          py_artifact <- py_lamin$Artifact$get(self$uid)
+        } else {
+          instance_settings <- private$.instance$get_settings()
+          slug <- paste0(instance_settings$owner, "/", instance_settings$name)
+
+          py_artifact <- py_lamin$Artifact$using(slug)$get(self$uid)
+        }
         return(py_artifact$cache()$path)
       }
 

--- a/R/Artifact.R
+++ b/R/Artifact.R
@@ -22,8 +22,8 @@ ArtifactRecord <- R6::R6Class( # nolint object_name_linter
       load_file(file_path, suffix, ...)
     },
     #' @description
-    #' Cache the artifact to the local filesystem. This currently only supports
-    #' S3 storage.
+    #' Cache the artifact to the local filesystem. When the Python `lamindb`
+    #' package is not available this only supports S3 storage.
     #'
     #' @return The path to the cached artifact
     cache = function() {

--- a/R/Instance.R
+++ b/R/Instance.R
@@ -59,23 +59,23 @@ create_instance <- function(instance_settings, is_default = FALSE) {
     active = active
   )
 
-  py_lamin <- NULL
-  if (isTRUE(is_default)) {
-    check_requires("Connecting to Python", "reticulate", type = "warning")
 
-    py_lamin <- tryCatch(
-      reticulate::import("lamindb"),
-      error = function(err) {
-        cli::cli_warn(c(
-          paste(
-            "Failed to connect to the Python {.pkg lamindb} package,",
-            "you will not be able to create records"
-          ),
-          "i" = "See {.run reticulate::py_config()} for more information"
-        ))
-        NULL
-      }
-    )
+  py_lamin <- NULL
+  check_requires("Connecting to Python", "reticulate", type = "warning")
+  py_lamin <- tryCatch(
+    reticulate::import("lamindb"),
+    error = function(err) {
+      NULL
+    }
+  )
+  if (isTRUE(is_default) && is.null(py_lamin)) {
+    cli::cli_warn(c(
+      paste(
+        "Default instance failed to connect to the Python {.pkg lamindb} package,",
+        "you will not be able to create records"
+      ),
+      "i" = "See {.run reticulate::py_config()} for more information"
+    ))
   }
 
   # create the instance

--- a/vignettes/development.qmd
+++ b/vignettes/development.qmd
@@ -77,6 +77,7 @@ This document outlines the features of the **{laminr}** package and the roadmap 
 * [x] **Track code execution**: Automatically track the execution of R scripts and notebooks.
 * [ ] **Capture run context**: Record information about the execution environment (e.g., package versions, parameters).
 * [x] **Link code to artifacts**: Associate code execution with generated artifacts.
+  - [x] Link to artifacts loaded from other instances
 * [ ] **Visualize data lineage**: Create visualizations of data lineage and dependencies.
 * [x] **Finalize tracking**: End and save a run.
 


### PR DESCRIPTION
**Related to:** Fixes #98 

## Description

- Add Python **lamindb** to all instances (if available)
  - Still warn for the default instance if not
- Use Python in `Artifact$cache()` (if available)
  - Fall back to the API if not with a warning

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] ~Update architecture vignette~
- [x] Update development vignette
- [ ] Update features in `README`
- [x] Update `CHANGELOG`
