### PR TITLE
🚸 Automatically refresh user tokens

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -68,9 +68,10 @@ jobs:
           pak::pkg_install("tiledbsoma")
         shell: Rscript {0}
 
-      - name: Install Python 3.12 on macOS
-        # We use python 3.12 on mac os x so we can install scipy 1.13 from a wheel
-        if: runner.os == 'macOS'
+      - name: Install Python 3.12 on macOS/Windows
+        # lamindb currently supports python>=3.10,<3.13 and 3.13 is installed
+        # macOS also previously required 3.12 to install scipy 1.13 from a wheel
+        if: runner.os == 'macOS' || runner.os == 'Windows'
         run: |
           reticulate::install_python(version = "3.12")
         shell: Rscript {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# laminr devel
+
+## MINOR CHANGES
+
+- Automatically refresh expired user tokens in `connect()` by running `lamin_login()` (PR #145)
+- `lamin_login()` now tries to use a stored user handle when arguments are not set (PR #145)
+
 # laminr v0.4.1
 
 ## MINOR CHANGES
@@ -14,8 +21,7 @@ Minor (breaking) changes to support the Python `lamindb` v1.0 release.
 
 ## MINOR CHANGES
 
-- `db$track()` can not automatically create a transform UID when not supplied (PR #136)
-
+- `db$track()` can now automatically create a transform UID when not supplied (PR #136)
 
 # laminr v0.3.1
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: laminr
 Title: Client for 'LaminDB'
-Version: 0.4.1
+Version: 0.4.1.9000
 Authors@R: c(
     person("Robrecht", "Cannoodt", email = "robrecht@data-intuitive.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3641-729X")),

--- a/R/Instance.R
+++ b/R/Instance.R
@@ -90,6 +90,14 @@ create_instance <- function(instance_settings, is_default = FALSE) {
     }
   }
 
+  if (is_default) {
+    instance_slug <- paste0(
+      instance_settings$owner, "/",
+      instance_settings$name
+    )
+    options(LAMINR_DEFAULT_INSTANCE = instance_slug)
+  }
+
   # create the instance
   RichInstance$new(
     settings = instance_settings,

--- a/R/InstanceAPI.R
+++ b/R/InstanceAPI.R
@@ -276,7 +276,7 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
       } else if (authorization_required) {
         cli::cli_abort(c(
           "There is no access token for the current user",
-          "i" = "Run {.run lamnin_login()} and reconnect to the database in a new R session"
+          "i" = "Run {.run lamin_login()} and reconnect to the database in a new R session"
         ))
       }
 

--- a/R/InstanceAPI.R
+++ b/R/InstanceAPI.R
@@ -37,7 +37,7 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
       )
 
       if (response$status_code == 500 &&
-          grepl("Invalid token", httr::content(response)$detail)) {
+        grepl("Invalid token", httr::content(response)$detail)) {
         cli::cli_alert(
           "Invalid token, attempting to refresh using {.code lamin_login()}..."
         )

--- a/R/InstanceAPI.R
+++ b/R/InstanceAPI.R
@@ -36,8 +36,10 @@ InstanceAPI <- R6::R6Class( # nolint object_name_linter
         httr::add_headers(.headers = private$get_headers())
       )
 
-      if (response$status_code == 500 &&
-        grepl("Invalid token", httr::content(response)$detail)) {
+      if (
+        response$status_code == 500 &&
+          grepl("Invalid token", httr::content(response)$detail)
+      ) {
         cli::cli_alert(
           "Invalid token, attempting to refresh using {.code lamin_login()}..."
         )

--- a/R/connect.R
+++ b/R/connect.R
@@ -237,16 +237,19 @@ lamin_login <- function(user = NULL, api_key = NULL) {
       system2("lamin", "login")
     })
   } else {
-    tryCatch({
-      handle <- .get_user_settings()$handle
-      cli::cli_alert_info("Using stored user handle {.val {handle}}")
-      system2("lamin", paste("login", handle))
-    }, error = function(err) {
-      if (Sys.getenv("LAMIN_API_KEY") == "") {
-        cli::cli_abort("{.arg LAMIN_API_KEY} is not set")
-      }
+    tryCatch(
+      {
+        handle <- .get_user_settings()$handle
+        cli::cli_alert_info("Using stored user handle {.val {handle}}")
+        system2("lamin", paste("login", handle))
+      },
+      error = function(err) {
+        if (Sys.getenv("LAMIN_API_KEY") == "") {
+          cli::cli_abort("{.arg LAMIN_API_KEY} is not set")
+        }
 
-      system2("lamin", "login")
-    })
+        system2("lamin", "login")
+      }
+    )
   }
 }

--- a/R/connect.R
+++ b/R/connect.R
@@ -237,9 +237,11 @@ lamin_login <- function(user = NULL, api_key = NULL) {
 
   if (!is.null(user)) {
     # If user is provided run `lamin login <user>`
+    cli::cli_alert_info("Using provided user {.val {user}}")
     system2("lamin", paste("login", user))
   } else if (!is.null(api_key)) {
     # If api_key is provided, run `lamin login` with the LAMIN_API_KEY env var
+    cli::cli_alert_info("Using provided API key")
     withr::with_envvar(c("LAMIN_API_KEY" = api_key), {
       system2("lamin", "login")
     })
@@ -247,9 +249,9 @@ lamin_login <- function(user = NULL, api_key = NULL) {
     # If there is a stored user handle run `lamin login <handle>`
     cli::cli_alert_info("Using stored user handle {.val {handle}}")
     system2("lamin", paste("login", handle))
-  } else if (Sys.getenv("LAMIN_API_KEY") == "") {
+  } else if (Sys.getenv("LAMIN_API_KEY") != "") {
     # If the LAMIN_API_KEY env var is already set run `lamin login`
-    cli::cli_abort("{.arg LAMIN_API_KEY} is not set")
+    cli::cli_alert_info("Using {.field LAMIN_API_KEY} environment variable")
     system2("lamin", "login")
   } else {
     # Fail to log in

--- a/R/install.R
+++ b/R/install.R
@@ -30,7 +30,6 @@
 #' }
 install_lamindb <- function(..., envname = "r-lamindb", extra_packages = NULL,
                             new_env = identical(envname, "r-lamindb")) {
-
   if (new_env && reticulate::virtualenv_exists(envname)) {
     reticulate::virtualenv_remove(envname)
   }
@@ -52,8 +51,7 @@ install_lamindb <- function(..., envname = "r-lamindb", extra_packages = NULL,
     }
 
   tryCatch(
-    switch(
-      env_type,
+    switch(env_type,
       virtualenv = reticulate::use_virtualenv(envname),
       conda = reticulate::use_condaenv(envname)
     ),

--- a/R/settings_load.R
+++ b/R/settings_load.R
@@ -79,7 +79,6 @@
 }
 
 .get_user_settings <- function(refresh = FALSE) {
-
   user_settings <- getOption("LAMINR_USER_SETTINGS")
 
   if (refresh || is.null(user_settings)) {

--- a/R/settings_load.R
+++ b/R/settings_load.R
@@ -37,7 +37,7 @@
   file <- .settings_store__current_user_settings_file()
 
   if (!file.exists(file)) {
-    cli_warn("using anonymous user (to identify, call `lamin login`)")
+    cli_warn("using anonymous user (to identify, run {.run lamin_login()})")
     content <- list(
       email = NULL,
       password = NULL,

--- a/R/settings_load.R
+++ b/R/settings_load.R
@@ -78,10 +78,11 @@
   UserSettings$new(store)
 }
 
-.get_user_settings <- function() {
+.get_user_settings <- function(refresh = FALSE) {
+
   user_settings <- getOption("LAMINR_USER_SETTINGS")
 
-  if (is.null(user_settings)) {
+  if (refresh || is.null(user_settings)) {
     user_settings <- .settings_load__load_or_create_user_settings()
     options("LAMINR_USER_SETTINGS" = user_settings)
   }

--- a/man/lamin_login.Rd
+++ b/man/lamin_login.Rd
@@ -16,7 +16,8 @@ Login as a LaminDB user
 }
 \details{
 Setting \code{user} will run \verb{lamin login <user>}. Setting \code{api_key} will set the
-\code{LAMIN_API_KEY} environment variable tempoarily with \code{withr::with_envvar()}
-and run \verb{lamin login}. If neither \code{user} or \code{api_key} are set \verb{lamin login}
-will be run if \code{LAMIN_API_KEY} is set.
+\code{LAMIN_API_KEY} environment variable temporarily with \code{withr::with_envvar()}
+and run \verb{lamin login}. If neither \code{user} or \code{api_key} are set the user handle
+will be retrieved from the user settings file. If that is not possible
+\verb{lamin login} will only be run if \code{LAMIN_API_KEY} is set.
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. Use dot points or a check list if needed -->

Automatically refresh user tokens when trying to connect to an instance with an invalid token instead of failing with an error message:

- Update `lamin_login()` to use a stored user handle when none is supplied
- Move setting the default instance to `create_instance()` so that it isn't set before a successful connection
- Add a `refresh` argument to `.get_user_settings()` to force ignoring the cache
- Check if the request failed in `api$get_schema()` due to an invalid token and if so call `lamin_login()`
to refresh the token and make a new request with updated he headers

## Checklist

**Before review**

- [x] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [x] Pass CI checks

**Before merge**

- [ ] Update architecture vignette
- [ ] Update development vignette
- [ ] Update features in `README`
- [x] Update `CHANGELOG`
