### PR TITLE
♻️ Dispatch CI from pre-release event in lamindb

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,6 +3,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  repository_dispatch:
+    types: [build]
 
 name: R-CMD-check.yaml
 
@@ -18,13 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: macos-latest, r: "release", python: "3.x", lamin: "release" }
-          - { os: windows-latest, r: "release", python: "3.x", lamin: "release" }
-          - { os: ubuntu-latest, r: "devel", http-user-agent: "release", python: "3.x", lamin: "release" }
-          - { os: ubuntu-latest, r: "release", python: "3.x", lamin: "release" }
-          - { os: ubuntu-latest, r: "oldrel-1", python: "3.9", lamin: "release" }
-          - { os: ubuntu-latest, r: "release", http-user-agent: "release", python: "3.x", lamin: "devel" }
-          - { os: ubuntu-latest, r: "devel", http-user-agent: "release", python: "3.x", lamin: "devel" }
+          - { os: ubuntu-latest, r: "release", python: "3.x"}        
+          - { os: windows-latest, r: "release", python: "3.x"}
+          - { os: ubuntu-latest, r: "devel", http-user-agent: "release", python: "3.x"}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -79,7 +77,7 @@ jobs:
       - name: Setup Python environment
         run: |
           laminr::install_lamindb(extra_packages = c("bionty"))
-          if ("${{ matrix.config.lamin }}" == "devel") {
+          if ("${{ github.event_name }}" == "repository_dispatch") {
             reticulate::use_virtualenv("r-lamindb")
             reticulate::py_install("git+https://github.com/laminlabs/lamindb.git")
           }

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -115,3 +115,20 @@ jobs:
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
+
+      - uses: voxmedia/github-action-slack-notify-build@v1
+        if: ${{ success() && github.event_name == 'repository_dispatch' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_GITHUB_ACTION }}
+        with:
+          channel_id: C05FDBBFJ1F
+          status: SUCCESS
+          color: good
+      - uses: voxmedia/github-action-slack-notify-build@v1
+        if: ${{ failure() && github.event_name == 'repository_dispatch' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_GITHUB_ACTION }}
+        with:
+          channel_id: C05FDBBFJ1F
+          status: FAILURE
+          color: danger

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -94,14 +94,10 @@ jobs:
       - name: Run tests for main docs
         run: Rscript test-docs/r-quickstart.R
       
-      - name: Install laminci
-        run: pip install laminci@git+https://github.com/laminlabs/laminci
-
-      - name: Upload scripts
+      - name: Upload docs
         run: |
-          from laminci import upload_docs_artifact
-          upload_docs_artifact(aws=True, docs_dir="./test-docs")
-        shell: python {0}
+          pip install laminci@git+https://github.com/laminlabs/laminci
+          laminci upload-docs --dir ./test-docs
 
       - name: Build LaminR docs
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -1,3 +1,5 @@
+name: test-docs
+
 on:
   push:
     branches: [main, master]
@@ -9,7 +11,6 @@ on:
     types: [build]
   workflow_dispatch:
 
-permissions: read-all
 
 jobs:
   pkgdown:

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -5,9 +5,9 @@ on:
     branches: [main, master]
   release:
     types: [published]
+  repository_dispatch:
+    types: [build]
   workflow_dispatch:
-
-name: build-docs.yaml
 
 permissions: read-all
 
@@ -137,3 +137,20 @@ jobs:
       #     body: |
       #       Deployment URL: ${{ steps.cloudflare.outputs.deployment-url }}
       #     edit-mode: replace
+
+      - uses: voxmedia/github-action-slack-notify-build@v1
+        if: ${{ success() && github.event_name == 'repository_dispatch' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_GITHUB_ACTION }}
+        with:
+          channel_id: C05FDBBFJ1F
+          status: SUCCESS
+          color: good
+      - uses: voxmedia/github-action-slack-notify-build@v1
+        if: ${{ failure() && github.event_name == 'repository_dispatch' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_GITHUB_ACTION }}
+        with:
+          channel_id: C05FDBBFJ1F
+          status: FAILURE
+          color: danger

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -1,3 +1,5 @@
+name: test-unit
+
 on:
   push:
     branches: [main]
@@ -6,7 +8,6 @@ on:
   repository_dispatch:
     types: [build]
 
-permissions: read-all
 
 jobs:
   R-CMD-check:

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -6,8 +6,6 @@ on:
   repository_dispatch:
     types: [build]
 
-name: R-CMD-check.yaml
-
 permissions: read-all
 
 jobs:


### PR DESCRIPTION
Rather than constantly running CI against pre-releases, we're now dispatching to laminr prior to making a release.

This keeps the overall runners smaller and is consistent with the many other integration tests we're running prior to making a release.

I've also slightly changed the naming conventions of the workflow files and hope that we can ultimately consolidate it in a single `test.yaml` or `build.yaml` so that things are easy to understand.

In particular the `test-docs.yaml` workflow can be simplified and we'll do so in future PRs.

Also added Slack notifs for dispatch events.