### PR TITLE
🐛 Allow running `lamin_connect()` multiple times

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -81,7 +81,7 @@ check_default_instance <- function(instance = NULL, alert = c("error", "warning"
   current_default <- get_default_instance()
   check <- !is.null(current_default)
 
-  if (check && !is.null(instance)) {
+  if (check && identical(instance, current_default)) {
     return(invisible(TRUE))
   }
 

--- a/R/checks.R
+++ b/R/checks.R
@@ -70,16 +70,22 @@ check_requires <- function(what, requires,
 #'
 #' Check if a default LaminDB instance has already been set
 #'
+#' @param instance A LaminDB instance slug. If this matches the current instance
+#'   no alert will be issued.
 #' @param alert The type of alert message to give
 #'
 #' @returns Whether to not there is a current default instance, invisibly
 #' @noRd
-check_default_instance <- function(alert = c("error", "warning", "message", "none")) {
+check_default_instance <- function(instance = NULL, alert = c("error", "warning", "message", "none")) {
   alert <- match.arg(alert)
   current_default <- get_default_instance()
   check <- !is.null(current_default)
-  msg_fun <- get_message_fun(alert)
 
+  if (check && !is.null(instance)) {
+    check <- !identical(instance, current_default)
+  }
+
+  msg_fun <- get_message_fun(alert)
   if (check && !is.null(msg_fun)) {
     advice <- switch(alert,
       error = c(

--- a/R/checks.R
+++ b/R/checks.R
@@ -82,7 +82,7 @@ check_default_instance <- function(instance = NULL, alert = c("error", "warning"
   check <- !is.null(current_default)
 
   if (check && !is.null(instance)) {
-    check <- !identical(instance, current_default)
+    return(invisible(TRUE))
   }
 
   msg_fun <- get_message_fun(alert)

--- a/R/lamin_cli.R
+++ b/R/lamin_cli.R
@@ -23,7 +23,7 @@ lamin_connect <- function(instance) {
     return(invisible(NULL))
   }
 
-  check_default_instance()
+  check_default_instance(instance)
 
   # Set the default environment if not set
   reticulate::use_virtualenv("r-lamindb", required = FALSE)

--- a/R/lamin_cli.R
+++ b/R/lamin_cli.R
@@ -23,7 +23,12 @@ lamin_connect <- function(instance) {
     return(invisible(NULL))
   }
 
-  check_default_instance(instance)
+  check <- check_default_instance(instance)
+
+  if (isTRUE(check)) {
+    cli::cli_alert("Already connected to {instance}")
+    return(invisible(NULL))
+  }
 
   # Set the default environment if not set
   reticulate::use_virtualenv("r-lamindb", required = FALSE)

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -75,6 +75,10 @@ test_that("check_default_instance() works", {
   expect_true(check_default_instance(alert = "none"))
 })
 
+test_that("check_default_instance() works with provided instance", {
+  expect_true(check_default_instance(get_current_lamin_instance()))
+})
+
 test_that("check_instance_module()", {
   expect_true(check_instance_module("bionty"))
 


### PR DESCRIPTION
**Related to:** #164 

## Description

<!-- Briefly describe what this PR does. Use dot points or a check list if needed -->

Allow running `lamin_connect()` multiple times with the same instance. Done by adding an instance argument to `check_default_instance()` that skips the check if it matches the current default instance.

Fixes #164.

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [x] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `CHANGELOG`
