### PR TITLE
🚸 Add env vars to contol the lamindb requirements

### DIFF
--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -22,7 +22,8 @@ jobs:
 
     env:
       LAMIN_API_KEY: ${{ secrets.LAMIN_API_KEY_TESTUSER1 }}
-      LAMIN_TEST_VERSION: ${{ github.event_name == 'repository_dispatch' && 'release' || 'devel' }}
+      LAMINR_LAMINDB_VERSION: ${{ github.event_name == 'repository_dispatch' && 'release' || 'devel' }}
+      LAMINR_LAMINDB_OPTIONS: 'bionty'
 
     steps:
       - name: Checkout
@@ -65,22 +66,20 @@ jobs:
           }
         shell: Rscript {0}
 
-      - name: Log in to Lamin
+      - name: Check lamindb requirements
+        run: |
+          message("LAMINR_LAMINDB_VERSION: ", Sys.getenv("LAMINR_LAMINDB_VERSION"))
+          message("LAMINR_LAMINDB_OPTIONS: ", Sys.getenv("LAMINR_LAMINDB_OPTIONS"))
+          laminr:::require_lamindb()
+          reticulate::py_require()
+          reticulate::py_config()
+          reticulate::py_list_packages()
+        shell: Rscript {0}
+
+      - name: Login and set lamindata as default instance
         run: |
           laminr::lamin_login()
-        shell: Rscript {0}
-
-      - name: Set lamindata as default instance
-        run: |
           laminr::lamin_connect("laminlabs/lamindata")
-        shell: Rscript {0}
-
-      - name: Check whether we can import lamindb and connect to the default instance
-        run: |
-          laminr::import_module("lamindb")
-          message("LAMIN_TEST_VERSION: ", Sys.getenv("LAMIN_TEST_VERSION"))
-          reticulate::py_config()
-          message("lamindb version: ", reticulate::py_get_attr(reticulate::import("lamindb"), "__version__"))
         shell: Rscript {0}
 
       - name: Prepare tests for main docs

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -29,7 +29,8 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       LAMIN_API_KEY: ${{ secrets.LAMIN_API_KEY_TESTUSER1 }}
-      LAMIN_TEST_VERSION: ${{ github.event_name == 'repository_dispatch' && 'release' || 'devel' }}
+      LAMINR_LAMINDB_VERSION: ${{ github.event_name == 'repository_dispatch' && 'release' || 'devel' }}
+      LAMINR_LAMINDB_OPTIONS: 'bionty'
 
     steps:
       - name: Checkout
@@ -51,22 +52,20 @@ jobs:
           extra-packages: any::rcmdcheck, local::.
           needs: check
 
-      - name: Log in to Lamin
+      - name: Check lamindb requirements
+        run: |
+          message("LAMINR_LAMINDB_VERSION: ", Sys.getenv("LAMINR_LAMINDB_VERSION"))
+          message("LAMINR_LAMINDB_OPTIONS: ", Sys.getenv("LAMINR_LAMINDB_OPTIONS"))
+          laminr:::require_lamindb()
+          reticulate::py_require()
+          reticulate::py_config()
+          reticulate::py_list_packages()
+        shell: Rscript {0}
+
+      - name: Login and set lamindata as default instance
         run: |
           laminr::lamin_login()
-        shell: Rscript {0}
-
-      - name: Set lamindata as default instance
-        run: |
           laminr::lamin_connect("laminlabs/lamindata")
-        shell: Rscript {0}
-
-      - name: Check whether we can import lamindb and connect to the default instance
-        run: |
-          laminr::import_module("lamindb")
-          message("LAMIN_TEST_VERSION: ", Sys.getenv("LAMIN_TEST_VERSION"))
-          reticulate::py_config()
-          message("lamindb version: ", reticulate::py_get_attr(reticulate::import("lamindb"), "__version__"))
         shell: Rscript {0}
 
       - name: Check

--- a/R/import.R
+++ b/R/import.R
@@ -14,6 +14,9 @@
 #' the module and used to create an ephemeral environment unless another
 #' environment is found (see `vignette("versions", package = "reticulate")`).
 #'
+#' Requirements for the `lamindb` module can be controlled using environment
+#' variables differently, see <https://docs.lamin.ai/setup-laminr> for details.
+#'
 #' @seealso
 #'
 #' - [require_module()] and [reticulate::py_require()] for defining Python
@@ -43,7 +46,11 @@ import_module <- function(module, ...) {
     check_instance_module(module)
   }
 
-  require_module(module, ...)
+  if (module == "lamindb") {
+    require_lamindb()
+  } else {
+    require_module(module, ...)
+  }
   check_requires(paste("Importing", module), module, language = "Python")
 
   py_module <- tryCatch(

--- a/man/import_module.Rd
+++ b/man/import_module.Rd
@@ -32,6 +32,9 @@ additional checks and nicer error messages.
 Python dependencies are set using \code{\link[=require_module]{require_module()}} before importing
 the module and used to create an ephemeral environment unless another
 environment is found (see \code{vignette("versions", package = "reticulate")}).
+
+Requirements for the \code{lamindb} module can be controlled using environment
+variables differently, see \url{https://docs.lamin.ai/setup-laminr} for details.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -3,20 +3,17 @@ if (isTRUE(as.logical(Sys.getenv("NOT_CRAN", "false")))) {
   timestamp <- format(Sys.time(), "%Y%m%d%H%M%S")
   test_name <- paste0("laminr-test-", timestamp)
 
-  if (Sys.getenv("LAMIN_TEST_VERSION") == "devel") {
-    require_module(
-      "lamindb",
-      options = "bionty",
-      source = "git+https://github.com/laminlabs/lamindb.git"
-    )
-  } else {
-    require_module("lamindb", options = "bionty")
-  }
-
-  # Make sure we are using the ephemeral environment
-  withr::with_envvar(c("RETICULATE_USE_MANAGED_VENV" = "yes"), {
-    reticulate::py_config()
-  })
+  # Make sure we are using the ephemeral environment with lamindb
+  withr::with_envvar(
+    c(
+      "RETICULATE_USE_MANAGED_VENV" = "yes",
+      "LAMINR_LAMINDB_OPTIONS" = "bionty" # Always include bionty for tests
+    ),
+    {
+      require_lamind
+      reticulate::py_config()
+    }
+  )
 
   # Reset the current instance when we are done
   current_instance <- laminr::get_current_lamin_instance()


### PR DESCRIPTION
<!--
Improve the heading of your PR by adding an emoji, e.g.:

- ✨ New feature
- 🐛 Bug fix
- 🚸 UX

To add emojis to all your commits, use [gitmoji](https://gitmoji.dev/).

1. Install with:

npm i -g gitmoji-cli

OR

brew install gitmoji

2. Install the gitmoji git hook

gitmoji -i
-->

**Related to:** <!-- Add links to related issues etc. here -->

## Description

<!-- Briefly describe what this PR does. Use dot points or a check list if needed -->

Add environment variables that can be used to control the version of options with `lamindb` is required. Most this is make managing CI and tests easier but could also be useful for users who want/need to control the `lamindb` version.

## Checklist

**Before review**

- [x] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `CHANGELOG`
