### PR TITLE
👷 Log bionty version

### DIFF
--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -95,6 +95,8 @@ jobs:
       - name: Check whether we can import bionty and are now connected to the new instance
         run: |
           laminr::import_module("lamindb")
+          message("instance modules: ", reticulate::import("lamindb_setup")$settings$instance$modules)
+          message("instance modules: ", reticulate::import("django.apps")$apps$get_app_configs())
           laminr::import_module("bionty")
           reticulate::py_config()
           message("bionty version: ", reticulate::py_get_attr(reticulate::import("bionty"), "__version__"))

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -78,9 +78,11 @@ jobs:
       - name: Check whether we can import lamindb and connect to the default instance
         run: |
           laminr::import_module("lamindb")
+          laminr::import_module("bionty")
           message("LAMIN_TEST_VERSION: ", Sys.getenv("LAMIN_TEST_VERSION"))
           reticulate::py_config()
           message("lamindb version: ", reticulate::py_get_attr(reticulate::import("lamindb"), "__version__"))
+          message("bionty version: ", reticulate::py_get_attr(reticulate::import("bionty"), "__version__"))
         shell: Rscript {0}
 
       - name: Prepare tests for main docs

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -86,6 +86,10 @@ jobs:
       - name: Prepare tests for main docs
         run: |
           laminr::lamin_init(storage = "./test-docs", modules = c("bionty"))
+          laminr::import_module("lamindb")
+          reticulate::py_config()
+          message("instance modules: ", reticulate::import("lamindb_setup")$settings$instance$modules)
+          message("bionty version: ", reticulate::py_get_attr(reticulate::import("bionty"), "__version__"))
         shell: Rscript {0}
 
       - name: Check whether we can import bionty and are now connected to the new instance

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -101,8 +101,10 @@ jobs:
           message("instance modules: ", reticulate::import("lamindb_setup")$settings$instance$modules)
         shell: Rscript {0}
 
-      - name: Run tests for main docs
-        run: Rscript test-docs/r-quickstart.R
+      - name: Run tests for main docs   
+        run: |
+          Rscript -e "library(reticulate); print(py_config()); if('bionty' %in% py_list_packages()$package) { cat('bionty version:', py_get_attr(import('bionty'), '__version__'), '\n') }"
+          Rscript test-docs/r-quickstart.R
 
       - name: Render markdown manual
         run: |

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -97,6 +97,7 @@ jobs:
           laminr::import_module("lamindb")
           message("instance modules: ", reticulate::import("lamindb_setup")$settings$instance$modules)
           message("instance modules: ", reticulate::import("django.apps")$apps$get_app_configs())
+          message("import bionty: ", reticulate::import("bionty"))
           laminr::import_module("bionty")
           reticulate::py_config()
           message("bionty version: ", reticulate::py_get_attr(reticulate::import("bionty"), "__version__"))

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -95,6 +95,7 @@ jobs:
       - name: Check whether we can import bionty and are now connected to the new instance
         run: |
           laminr::import_module("lamindb")
+          reticulate::py_config()
           message("instance modules: ", reticulate::import("lamindb_setup")$settings$instance$modules)
           message("instance modules: ", reticulate::import("django.apps")$apps$get_app_configs())
           message("import bionty: ", reticulate::import("bionty"))

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -98,11 +98,11 @@ jobs:
           reticulate::py_config()
           message("instance modules: ", reticulate::import("lamindb_setup")$settings$instance$modules)
           message("instance modules: ", reticulate::import("django.apps")$apps$get_app_configs())
-          message("import bionty: ", reticulate::import("bionty"))
-          laminr::import_module("bionty")
-          reticulate::py_config()
-          message("bionty version: ", reticulate::py_get_attr(reticulate::import("bionty"), "__version__"))
-          message("instance modules: ", reticulate::import("lamindb_setup")$settings$instance$modules)
+          # message("import bionty: ", reticulate::import("bionty"))
+          # laminr::import_module("bionty")
+          # reticulate::py_config()
+          # message("bionty version: ", reticulate::py_get_attr(reticulate::import("bionty"), "__version__"))
+          # message("instance modules: ", reticulate::import("lamindb_setup")$settings$instance$modules)
         shell: Rscript {0}
 
       - name: Run tests for main docs   

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -88,11 +88,13 @@ jobs:
           laminr::lamin_init(storage = "./test-docs", modules = c("bionty"))
         shell: Rscript {0}
 
-      - name: Check whether we can import bionty
+      - name: Check whether we can import bionty and are now connected to the new instance
         run: |
+          laminr::import_module("lamindb")
           laminr::import_module("bionty")
           reticulate::py_config()
           message("bionty version: ", reticulate::py_get_attr(reticulate::import("bionty"), "__version__"))
+          message("instance modules: ", reticulate::import("lamindb_setup")$settings$instance$modules)
         shell: Rscript {0}
 
       - name: Run tests for main docs

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -78,16 +78,21 @@ jobs:
       - name: Check whether we can import lamindb and connect to the default instance
         run: |
           laminr::import_module("lamindb")
-          laminr::import_module("bionty")
           message("LAMIN_TEST_VERSION: ", Sys.getenv("LAMIN_TEST_VERSION"))
           reticulate::py_config()
           message("lamindb version: ", reticulate::py_get_attr(reticulate::import("lamindb"), "__version__"))
-          message("bionty version: ", reticulate::py_get_attr(reticulate::import("bionty"), "__version__"))
         shell: Rscript {0}
 
       - name: Prepare tests for main docs
         run: |
           laminr::lamin_init(storage = "./test-docs", modules = c("bionty"))
+        shell: Rscript {0}
+
+      - name: Check whether we can import bionty
+        run: |
+          laminr::import_module("bionty")
+          reticulate::py_config()
+          message("bionty version: ", reticulate::py_get_attr(reticulate::import("bionty"), "__version__"))
         shell: Rscript {0}
 
       - name: Run tests for main docs

--- a/test-docs/r-quickstart.R
+++ b/test-docs/r-quickstart.R
@@ -1,5 +1,5 @@
 library(laminr)
-laminr::lamin_connect("testuser1/test-docs")
+laminr::lamin_init(storage = "./test-docs-2", modules = c("bionty"))
 ln <- import_module("lamindb")  # instantiate the central object of the API
 ln_setup <- reticulate::import("lamindb_setup")
 message("instance modules:", ln_setup$settings$instance$modules)

--- a/test-docs/r-quickstart.R
+++ b/test-docs/r-quickstart.R
@@ -1,4 +1,5 @@
 library(laminr)
+laminr::lamin_connect("testuser1/test-docs")
 ln <- import_module("lamindb")  # instantiate the central object of the API
 ln_setup <- reticulate::import("lamindb_setup")
 message("instance modules:", ln_setup$settings$instance$modules)

--- a/test-docs/r-quickstart.R
+++ b/test-docs/r-quickstart.R
@@ -1,5 +1,6 @@
 library(laminr)
 ln <- import_module("lamindb")  # instantiate the central object of the API
+bt <- import_module("bionty") 
 
 # Access inputs -------------------------------------------
 

--- a/test-docs/r-quickstart.R
+++ b/test-docs/r-quickstart.R
@@ -1,6 +1,7 @@
 library(laminr)
 ln <- import_module("lamindb")  # instantiate the central object of the API
-bt <- import_module("bionty") 
+ln_setup <- reticulate::import("lamindb_setup")
+message("instance modules:", ln_setup$settings$instance$modules)
 
 # Access inputs -------------------------------------------
 


### PR DESCRIPTION
This function returns that `bionty` isn't configured even though it clearly is in `test-docs`.

https://github.com/laminlabs/laminr/blob/8a85a7c521f1a5a424dbc02dc0d1c68f5e1c1ee1/R/checks.R#L119-L144

Similarly, other calls within Python indicate that `bionty` isn't installed. This PR tries to debug and fix these issues.