### PR TITLE
:bug: Surround pak lockfile creation with try-catch to avoid breaking the finish process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# laminr v1.1.1
+
+## BUG FIXES
+
+- Surround pak lockfile creation with try-catch to avoid breaking the finish process (PR #198).
+
 # laminr v1.1.0
 
 ## NEW FEATURES


### PR DESCRIPTION
Adds a workaround for pak::lockfile_create throwing errors during the finish process.


**Related to:** #195 

## Description


If pak::lockfile_create fails for some reason or another, it will show the following error message:

<details><summary>Code</summary>

```r
pkgs <- c("thispackagedoesnotexist")
pkg_repos <- c()
run_dir <- tempdir()

# updated code:
tryCatch(
  withr::with_options(
    list(repos = unique(c(pkg_repos, getOption("repos")))),
    {
      pak::lockfile_create(
        pkg = pkgs,
        lockfile = file.path(run_dir, "r_pak_lockfile.json")
      )
    }
  ),
  error = function(err) {
    cli::cli_warn(
      c(
        "Failed to create the lockfile for the run using pak.",
        "i" = "Please reach out via GitHub or Slack if you need help.",
        "x" = "Error message: {err}"
      )
    )
  }
)
```

</details>

Error message:

    ✖ Creating lockfile /tmp/Rtmpw3CZ7F/r_pak_lockfile.json [1.6s]
    Warning message:
    Failed to create the lockfile for the run using pak.
    ℹ Please reach out via GitHub or Slack if you need help.
    ✖ Error message: Error: ! error in pak subprocess Caused by error: ! Could not solve package dependencies: * thispackagedoesnotexist: Can't find package called thispackagedoesnotexist. 

![image](https://github.com/user-attachments/assets/c821eeac-2fc4-4fc9-8e88-cb87b33ff2f7)


## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `CHANGELOG`
