### PR TITLE
🐛 Handle NULL `doc_context$id` in `detect_path()`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -179,7 +179,7 @@ detect_path <- function() {
   # Get path if in a document in RStudio
   if (is.null(current_path) && is_rstudio()) {
     doc_context <- rstudioapi::getActiveDocumentContext()
-    if (doc_context$id != "#console") {
+    if (is.null(doc_context$id) || doc_context$id != "#console") {
       current_path <- doc_context$path
     }
   }


### PR DESCRIPTION
<!--
Improve the heading of your PR by adding an emoji, e.g.:

- ✨ New feature
- 🐛 Bug fix
- 🚸 UX

To add emojis to all your commits, use [gitmoji](https://gitmoji.dev/).

1. Install with:

npm i -g gitmoji-cli

OR

brew install gitmoji

2. Install the gitmoji git hook

gitmoji -i
-->

**Related to:** <!-- Add links to related issues etc. here -->

## Description

<!-- Briefly describe what this PR does. Use dot points or a check list if needed -->

Handle edge case where the document context can be missing an `id` value in `detect_path()`. Came up when testing things in Positron but might happen in other places.

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [x] Pass CI checks

**Before merge**

- [ ] Update `CHANGELOG`
