### PR TITLE
✨ Add wrapping for Registry$from_dataframe()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,15 @@
 - Remove **{nanoparquet}** as a suggested dependency, loading Parquet files now requires **{arrow}** (PR #203)
 - Increase **{reticulate}** dependency to `>=1.41.0` to make sure the `py_require()` functionality is available (PR #208)
 - Add a minimal requirement for `scipy>=1.7` to avoid an issue where **{reticulate}** attempted and failed to install `scipy==1.6` (PR #209, fixes #206)
+- Disable Python ANSI colour codes in RMarkdown documents (PR #217)
+- Remove **{Seurat}** as a suggested dependency (PR #219, fixes #216)
+- Add wrapping for the new `Registry$from_dataframe()` method (PR #221)
 
 ## BUG FIXES
 
 - Handle missing setting values in `lamin_settings()` (PR #202)
 - Handle list columns when creating artifacts from data frames (PR #203)
+- Handle missing document context ID when detecting the current path for tracking (PR #220)
 
 ## TESTING
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: laminr
 Title: Client for 'LaminDB'
-Version: 1.1.1.9007
+Version: 1.1.1.9008
 Authors@R: c(
     person("Robrecht", "Cannoodt", , "robrecht@lamin.ai", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3641-729X")),

--- a/R/Registry.R
+++ b/R/Registry.R
@@ -1,25 +1,24 @@
 #' @export
 py_to_r.lamindb.models.record.Registry <- function(x) {
-  wrap_python_callable(
-    x,
-    public = list(
-      from_df = if ("from_df" %in% names(x)) {
-        wrap_with_py_arguments(registry_from_df, x$from_df)
-      }
-    ) |>
-      purrr::compact()
-  )
+  wrap_registry(x)
 }
 
 #' @export
 # nolint start: object_length_linter
 py_to_r.lamindb.models.sqlrecord.Registry <- function(x) {
   # nolint end: object_length_linter
-  wrap_python_callable(
+  wrap_registry(x)
+}
+
+wrap_registry <- function(py_registry) {
+    wrap_python_callable(
     x,
     public = list(
       from_df = if ("from_df" %in% names(x)) {
         wrap_with_py_arguments(registry_from_df, x$from_df)
+      },
+      from_dataframe = if ("from_dataframe" %in% names(x)) {
+        wrap_with_py_arguments(registry_from_df, x$from_dataframe)
       }
     ) |>
       purrr::compact()


### PR DESCRIPTION
<!--
Improve the heading of your PR by adding an emoji, e.g.:

- ✨ New feature
- 🐛 Bug fix
- 🚸 UX

To add emojis to all your commits, use [gitmoji](https://gitmoji.dev/).

1. Install with:

npm i -g gitmoji-cli

OR

brew install gitmoji

2. Install the gitmoji git hook

gitmoji -i
-->

**Related to:** <!-- Add links to related issues etc. here -->

## Description

<!-- Briefly describe what this PR does. Use dot points or a check list if needed -->

Add wrapping for the new `Registry$from_dataframe()` method. Either/both `from_dataframe()` and `from_df()` will be wrapped depending on what is in the Python object.

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [x] Update `CHANGELOG`
