### PR TITLE
🚸 Simplify connecting to an instance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: laminr
 Title: Client for 'LaminDB'
-Version: 1.2.2.9005
+Version: 1.2.2.9006
 Authors@R: c(
     person("Robrecht", "Cannoodt", , "robrecht@lamin.ai", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3641-729X")),

--- a/R/checks.R
+++ b/R/checks.R
@@ -130,25 +130,20 @@ check_default_instance <- function(instance = NULL, alert = c("error", "warning"
 #' @returns Whether `module` is included in the current instance, invisibly
 #' @noRd
 check_instance_module <- function(module, alert = c("error", "warning", "message", "none")) {
-  current_default <- get_default_instance()
   msg_fun <- get_message_fun(alert)
 
-  # If there is no current instance just return
-  if (is.null(current_default)) {
+  current_instance <- get_current_lamin_instance(ignore_none = FALSE, silent = TRUE)
+  if (is.null(current_instance)) {
     return()
   }
 
-  ln_setup <- reticulate::import("lamindb_setup")
-
-  check <- try(
-    ln_setup$`_check_setup`$`_check_module_in_instance_modules`(module),
-    silent = TRUE
-  )
-  check <- !inherits(check, "try-error")
+  settings <- get_current_lamin_settings(silent = TRUE)
+  instance_modules <- settings$instance$modules
+  check <- module %in% instance_modules
 
   if (isFALSE(check) && !is.null(msg_fun)) {
     msg_fun(
-      "The current instance ({.val {current_default}}) does not include the {.pkg {module}} module",
+      "The current instance ({.val {current_instance}}) does not include the {.pkg {module}} module",
       call = rlang::caller_env()
     )
   }

--- a/R/file_loaders.R
+++ b/R/file_loaders.R
@@ -62,6 +62,8 @@ load_anndata_zarr <- function(file, ...) {
 load_parquet <- function(file, ...) {
   check_requires("Reading Parquet files", "arrow")
 
+  df <- arrow::read_parquet(file, ...)
+
   # If there is a "__index_level_0__" column, convert to data.frame and
   # set row names
   if ("__index_level_0__" %in% colnames(df)) {

--- a/R/import.R
+++ b/R/import.R
@@ -83,8 +83,7 @@ import_module <- function(module, ...) {
   }
 
   if (module == "lamindb") {
-    settings <- get_current_lamin_settings(minimal = TRUE)
-    wrap_lamindb(py_module, settings)
+    wrap_lamindb(py_module)
   } else {
     py_module
   }

--- a/R/import.R
+++ b/R/import.R
@@ -48,12 +48,11 @@ import_module <- function(module, ...) {
 
   laminr_lamindb_version <- trimws(tolower(Sys.getenv("LAMINR_LAMINDB_VERSION")))
   lamin_modules <- c(
-    "lamindb", "lamindb_setup", "lamin_utils", "lamin_cli", "bionty"
+    "lamindb", "lamindb_setup", "lamin_utils", "lamin_cli", "bionty", "pertdb"
   )
 
   if (module == "lamindb") {
-    settings <- get_current_lamin_settings(minimal = TRUE)
-    init_lamindb_connection(settings, ...)
+    require_lamindb(...)
   } else if (
     module %in% lamin_modules &&
       laminr_lamindb_version %in% c("github", "devel")
@@ -84,6 +83,7 @@ import_module <- function(module, ...) {
   }
 
   if (module == "lamindb") {
+    settings <- get_current_lamin_settings(minimal = TRUE)
     wrap_lamindb(py_module, settings)
   } else {
     py_module

--- a/R/lamindb.R
+++ b/R/lamindb.R
@@ -2,7 +2,7 @@ wrap_lamindb <- function(py_lamindb) {
   lamin_version <- reticulate::py_get_attr(py_lamindb, "__version__")
   lamin_version_clean <- sub("([a-zA-Z].*)", "", lamin_version) # Remove pre-release versions, e.g. 1.0a5 -> 1.0
   min_version <- "2.0.0"
-  expected_version <- "2.0.0"
+  expected_version <- "2.3.0"
   if (utils::compareVersion(min_version, lamin_version_clean) == 1) {
     cli::cli_abort(c(
       "This version of {.pkg laminr} requires Python {.pkg lamindb} >= v{min_version}",

--- a/R/lamindb.R
+++ b/R/lamindb.R
@@ -1,4 +1,4 @@
-wrap_lamindb <- function(py_lamindb, settings) {
+wrap_lamindb <- function(py_lamindb) {
   lamin_version <- reticulate::py_get_attr(py_lamindb, "__version__")
   lamin_version_clean <- sub("([a-zA-Z].*)", "", lamin_version) # Remove pre-release versions, e.g. 1.0a5 -> 1.0
   min_version <- "2.0.0"
@@ -16,6 +16,7 @@ wrap_lamindb <- function(py_lamindb, settings) {
     ))
   }
 
+  settings <- get_current_lamin_settings()
   instance_slug <- settings$instance$slug
   if (!is.null(instance_slug)) {
     # Warn if instance modules are not available

--- a/R/lamindb.R
+++ b/R/lamindb.R
@@ -114,37 +114,3 @@ lamindb_finish <- function(self, ...) {
     }
   )
 }
-
-#' Initialise LaminDB connection
-#'
-#' Performs setup in preparation for connecting to a LaminDB instance that must
-#' be done _before_ importing the Python `lamindb` module.
-#'
-#' @param settings A list of LaminDB settings returned by
-#'   [get_current_lamin_settings()]
-#' @param ... Additional arguments passed to `require_lamindb()` and
-#'   `require_module()`
-#'
-#' @returns NULL, invisibly
-#' @noRd
-init_lamindb_connection <- function(settings, ...) {
-  require_lamindb(...)
-
-  instance_slug <- settings$instance$slug
-  if (is.null(instance_slug)) {
-    cli::cli_abort(
-      "No instance is loaded. Call {.code lamin_init()} or {.code lamin_connect()}"
-    )
-  }
-
-  if (is.null(get_default_instance())) {
-    instance_modules <- settings$instance$modules
-    for (module in instance_modules) {
-      require_module(module, ...)
-    }
-
-    set_default_instance(instance_slug)
-  }
-
-  invisible()
-}

--- a/R/lamindb.R
+++ b/R/lamindb.R
@@ -27,27 +27,6 @@ wrap_lamindb <- function(py_lamindb, settings) {
       alert = "message",
       info = c("!" = "This should be done {.emph before} connecting to any instance")
     )
-
-    tryCatch(
-      storage <- reticulate::py_repr(py_lamindb$settings$storage), # nolint object_usage_linter
-      error = function(err) {
-        cli::cli_abort(
-          c(
-            paste(
-              "Failed to identify storage for instance {.val {instance_slug}}.",
-              "The directory for this instance may have been deleted."
-            ),
-            "i" = paste(
-              "Restart your R session and use",
-              "{.code lc <- import_module(\"lamin_cli\"); lc$connect()}",
-              "to connect to another instance"
-            ),
-            "x" = "Error message: {err}"
-          ),
-          call = rlang::caller_env(4)
-        )
-      }
-    )
   }
 
   reticulate::register_module_help_handler(
@@ -156,7 +135,6 @@ init_lamindb_connection <- function(settings, ...) {
     cli::cli_abort(
       "No instance is loaded. Call {.code lamin_init()} or {.code lamin_connect()}"
     )
-    return(invisible(NULL))
   }
 
   if (is.null(get_default_instance())) {

--- a/R/require.R
+++ b/R/require.R
@@ -137,16 +137,15 @@ require_lamindb <- function(silent = FALSE) {
 
     reticulate::py_require(python_version = ">=3.10,<3.14")
 
+    if (is.null(laminr_lamindb_options)) {
+      laminr_lamindb_options <- "full" # Get all dependencies by default
+    }
+
     # Also require matching devel versions of other lamin packages
     require_module(
       "lamindb_setup",
       options = "aws",
       source = "git+https://github.com/laminlabs/lamindb.git#subdirectory=sub/lamindb-setup",
-      silent = silent
-    )
-    require_module(
-      "lamin_utils",
-      source = "git+https://github.com/laminlabs/lamin-utils.git",
       silent = silent
     )
     require_module(
@@ -160,7 +159,12 @@ require_lamindb <- function(silent = FALSE) {
       silent = silent
     )
     require_module(
-      "lamindb",
+      "pertdb",
+      source = "git+https://github.com/laminlabs/lamindb.git#subdirectory=sub/pertdb",
+      silent = silent
+    )
+    require_module(
+      "lamindb-core", # Main pyproject.toml specifies lamindb-core without dependencies
       options = laminr_lamindb_options,
       source = "git+https://github.com/laminlabs/lamindb.git",
       silent = silent

--- a/R/status.R
+++ b/R/status.R
@@ -33,8 +33,8 @@ laminr_status <- function() {
     status_list$env_vars <- as.list(env_vars)
   }
 
-  if (!is.null(get_default_instance())) {
-    settings <- get_current_lamin_settings(minimal = TRUE)
+  settings <- get_current_lamin_settings(minimal = TRUE)
+  if (!is.null(settings)) {
     status_list$settings <- list(
       user = settings$user$handle,
       instance = settings$instance$slug

--- a/R/status.R
+++ b/R/status.R
@@ -107,7 +107,7 @@ format.laminr_status <- function(x, ...) {
       cli::cli_bullets(c(
         "i" = paste(
           "To change the instance, use",
-          "{.code lc <- import_module(\"lamin_cli\"); lc$connect()}"
+          "{.code ln <- import_module(\"lamindb\"); ln$connect()}"
         ),
         "i" = paste(
           "Run {.run get_current_lamin_settings()}",

--- a/R/status.R
+++ b/R/status.R
@@ -33,11 +33,11 @@ laminr_status <- function() {
     status_list$env_vars <- as.list(env_vars)
   }
 
-  settings <- get_current_lamin_settings(minimal = TRUE)
+  settings <- get_current_lamin_settings(minimal = TRUE, silent = TRUE)
   if (!is.null(settings)) {
     status_list$settings <- list(
-      user = settings$user$handle,
-      instance = settings$instance$slug
+      user = get_current_lamin_user(silent = TRUE),
+      instance = get_current_lamin_instance(silent = TRUE)
     )
   }
 
@@ -101,8 +101,16 @@ format.laminr_status <- function(x, ...) {
 
     cli::cli_h2("Settings")
     if (!is.null(x$settings)) {
-      cli::cli_text("{.field User}: {.val {x$settings$user}}")
-      cli::cli_text("{.field Instance}: {.val {x$settings$instance}}")
+      if (!is.null(x$settings$user)) {
+        cli::cli_text("{.field User}: {.val {x$settings$user}}")
+      } else {
+        cli::cli_alert_danger("No user found")
+      }
+      if (!is.null(x$settings$instance)) {
+        cli::cli_text("{.field Instance}: {.val {x$settings$instance}}")
+      } else {
+        cli::cli_alert_danger("No instance connected")
+      }
       cli::cli_text()
       cli::cli_bullets(c(
         "i" = paste(
@@ -115,7 +123,7 @@ format.laminr_status <- function(x, ...) {
         )
       ))
     } else {
-      cli::cli_alert_danger("Not connected to an instance")
+      cli::cli_alert_danger("Unable to get settings")
     }
 
     if (!is.null(x$python)) {

--- a/R/temporary-instance.R
+++ b/R/temporary-instance.R
@@ -29,70 +29,53 @@ use_temporary_instance <- function(name = "laminr-temp", modules = NULL,
     name <- paste0(name, "-", timestamp)
   }
 
+  py_lamindb <- import_module("lamindb")
+
   # Get the current instance to reset later
   current_instance <- get_current_lamin_instance(silent = TRUE)
-  callr::r(
-    function() {
-      lc <- laminr::import_module("lamin_cli", silent = TRUE)
-      lc$disconnect()
-    }
-  )
+  cli::cli_alert_info("Current instance: {.val {current_instance}}")
+  py_lamindb$setup$disconnect()
 
   # Create the temporary storage for this instance
   temp_storage <- file.path(tempdir(), name)
 
-  # Initialise the temporary instance
-  callr::r(
-    function(storage, name, modules) {
-      require_lamindb(silent = TRUE)
+  if (!is.null(modules)) {
+    for (module in modules) {
+      require_module(module, silent = TRUE)
+    }
 
-      if (!is.null(modules)) {
-        for (module in modules) {
-          require_module(module, silent = TRUE)
-        }
-      }
-      lc <- import_module("lamin_cli", silent = TRUE)
+    check_requires(
+      "Initialising a database with these modules", modules,
+      language = "Python"
+    )
+    modules_str <- paste(modules, collapse = ",")
+  } else {
+    modules_str <- NULL
+  }
 
-      if (!is.null(modules)) {
-        check_requires(
-          "Initialising a database with these modules", modules,
-          language = "Python"
-        )
-        modules_str <- paste(modules, collapse = ",")
-      } else {
-        modules_str <- NULL
-      }
+  py_lamindb$setup$init(
+    storage = temp_storage,
+    name = name,
+    modules = modules_str
+  )
 
-      lc$init(
-        storage = storage,
-        name = name,
-        modules = modules_str
-      )
-    },
-    args = list(storage = temp_storage, name = name, modules = modules),
-    package = "laminr"
-  ) |>
-    print_stdout()
-
-  temp_instance <- laminr::get_current_lamin_instance()
+  temp_instance <- get_current_lamin_instance(silent = TRUE)
+  cli::cli_alert_info("Temporary instance: {.val {temp_instance}}")
 
   # Add the clean up handler to the environment
   withr::defer(
     {
-      lc <- laminr::import_module("lamin_cli", silent = TRUE)
-
       # Disconnect from the temporary instance
-      lc$disconnect()
+      py_lamindb$setup$disconnect()
 
       # Delete the temporary instance
-      py_lamindb_setup <- laminr::import_module("lamindb_setup", silent = TRUE)
-      py_lamindb_setup$delete(temp_instance, force = TRUE, require_empty = FALSE)
+      py_lamindb$setup$delete(temp_instance, force = TRUE, require_empty = FALSE)
 
       # Try to reconnect to the previous instance
       if (!is.null(current_instance)) {
         tryCatch(
           {
-            lc$connect(current_instance)
+            py_lamindb$connect(current_instance)
           },
           error = function(err) {
             cli::cli_warn(c(

--- a/R/temporary-instance.R
+++ b/R/temporary-instance.R
@@ -30,7 +30,7 @@ use_temporary_instance <- function(name = "laminr-temp", modules = NULL,
   }
 
   # Get the current instance to reset later
-  current_instance <- laminr::get_current_lamin_instance()
+  current_instance <- get_current_lamin_instance(silent = TRUE)
   callr::r(
     function() {
       lc <- laminr::import_module("lamin_cli", silent = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -50,29 +50,28 @@ get_default_instance <- function() {
 #' This is done using [callr::r()] to avoid importing Python `lamindb` in the
 #' global environment
 get_current_lamin_settings <- function(minimal = FALSE) {
-  call_fun <- function(minimal) {
-    require_lamindb(silent = TRUE)
-    py_ln <- reticulate::import("lamindb")
-
-    py_settings <- py_ln$setup$settings
-
-    if (minimal) {
-      py_builtins <- reticulate::import_builtins()
-      list(
-        instance = list(
-          slug = py_settings$instance$slug,
-          modules = py_builtins$list(py_settings$instance$modules)
-        ),
-        user = list(
-          handle = py_settings$user$handle
-        )
-      )
-    } else {
-      py_settings_to_list(py_settings)
-    }
+  if (!reticulate::py_available() && !reticulate::py_module_available("lamindb")) {
+    cli::cli_alert_danger("Python {.pkg lamindb} is not available, cannot get settings")
+    return(invisible(NULL))
   }
 
-  callr::r(call_fun, args = list(minimal = minimal), package = "laminr")
+  py_lamindb <- reticulate::import("lamindb")
+  py_settings <- py_lamindb$setup$settings
+
+  if (minimal) {
+    py_builtins <- reticulate::import_builtins()
+    list(
+      instance = list(
+        slug = py_settings$instance$slug,
+        modules = py_builtins$list(py_settings$instance$modules)
+      ),
+      user = list(
+        handle = py_settings$user$handle
+      )
+    )
+  } else {
+    py_settings_to_list(py_settings)
+  }
 }
 
 #' Get current LaminDB user

--- a/R/utils.R
+++ b/R/utils.R
@@ -101,17 +101,19 @@ get_current_lamin_user <- function(silent = FALSE) {
 #'
 #' Get the currently connected LaminDB instance
 #'
+#' @param ignore_none Whether to ignore the `"none/none"` virtual instance as a
+#'   valid instance and return `NULL`
 #' @param silent Whether to suppress messages
 #'
 #' @returns The slug of the current LaminDB instance, or `NULL` invisibly if no
 #'   instance is found
 #' @export
-get_current_lamin_instance <- function(silent = FALSE) {
+get_current_lamin_instance <- function(ignore_none = TRUE, silent = FALSE) {
   settings <- get_current_lamin_settings(minimal = TRUE, silent = silent)
 
   instance_slug <- settings$instance$slug
 
-  if (is.null(instance_slug) || instance_slug == "none/none") {
+  if (is.null(instance_slug) || (ignore_none && identical(instance_slug, "none/none"))) {
     if (!silent) {
       cli::cli_alert_danger("No current instance")
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -42,16 +42,15 @@ get_default_instance <- function() {
 #'
 #' @param minimal If `TRUE`, quickly extract a minimal list of important
 #'  settings instead of converting the complete settings object
+#' @param silent Whether to suppress messages
 #'
 #' @returns A list of the current LaminDB settings
 #' @export
-#'
-#' @details
-#' This is done using [callr::r()] to avoid importing Python `lamindb` in the
-#' global environment
-get_current_lamin_settings <- function(minimal = FALSE) {
+get_current_lamin_settings <- function(minimal = FALSE, silent = FALSE) {
   if (!reticulate::py_available() || !reticulate::py_module_available("lamindb")) {
-    cli::cli_alert_danger("Python {.pkg lamindb} is not available, cannot get settings")
+    if (!silent) {
+      cli::cli_alert_danger("Python {.pkg lamindb} is not available, cannot get settings")
+    }
     return(invisible(NULL))
   }
 
@@ -78,20 +77,20 @@ get_current_lamin_settings <- function(minimal = FALSE) {
 #'
 #' Get the currently logged in LaminDB user
 #'
+#' @param silent Whether to suppress messages
+#'
 #' @returns The handle of the current LaminDB user, or `NULL` invisibly if no
 #'   user is found
 #' @export
-#'
-#' @details
-#' This is done via [get_current_lamin_settings()] to avoid importing Python
-#' `lamindb`
-get_current_lamin_user <- function() {
-  settings <- get_current_lamin_settings(minimal = TRUE)
+get_current_lamin_user <- function(silent = FALSE) {
+  settings <- get_current_lamin_settings(minimal = TRUE, silent = silent)
 
   handle <- settings$user$handle
 
   if (is.null(handle)) {
-    cli::cli_alert_danger("No current user")
+    if (!silent) {
+      cli::cli_alert_danger("No current user")
+    }
     return(invisible(NULL))
   }
 
@@ -102,20 +101,20 @@ get_current_lamin_user <- function() {
 #'
 #' Get the currently connected LaminDB instance
 #'
+#' @param silent Whether to suppress messages
+#'
 #' @returns The slug of the current LaminDB instance, or `NULL` invisibly if no
 #'   instance is found
 #' @export
-#'
-#' @details
-#' This is done via a [get_current_lamin_settings()] to avoid importing Python
-#' `lamindb`
-get_current_lamin_instance <- function() {
-  settings <- get_current_lamin_settings(minimal = TRUE)
+get_current_lamin_instance <- function(silent = FALSE) {
+  settings <- get_current_lamin_settings(minimal = TRUE, silent = silent)
 
   instance_slug <- settings$instance$slug
 
-  if (is.null(instance_slug)) {
-    cli::cli_alert_danger("No current instance")
+  if (is.null(instance_slug) || instance_slug == "none/none") {
+    if (!silent) {
+      cli::cli_alert_danger("No current instance")
+    }
     return(invisible(NULL))
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -50,7 +50,7 @@ get_default_instance <- function() {
 #' This is done using [callr::r()] to avoid importing Python `lamindb` in the
 #' global environment
 get_current_lamin_settings <- function(minimal = FALSE) {
-  if (!reticulate::py_available() && !reticulate::py_module_available("lamindb")) {
+  if (!reticulate::py_available() || !reticulate::py_module_available("lamindb")) {
     cli::cli_alert_danger("Python {.pkg lamindb} is not available, cannot get settings")
     return(invisible(NULL))
   }

--- a/man/get_current_lamin_instance.Rd
+++ b/man/get_current_lamin_instance.Rd
@@ -4,7 +4,13 @@
 \alias{get_current_lamin_instance}
 \title{Get current LaminDB instance}
 \usage{
-get_current_lamin_instance()
+get_current_lamin_instance(ignore_none = TRUE, silent = FALSE)
+}
+\arguments{
+\item{ignore_none}{Whether to ignore the \code{"none/none"} virtual instance as a
+valid instance and return \code{NULL}}
+
+\item{silent}{Whether to suppress messages}
 }
 \value{
 The slug of the current LaminDB instance, or \code{NULL} invisibly if no
@@ -12,8 +18,4 @@ instance is found
 }
 \description{
 Get the currently connected LaminDB instance
-}
-\details{
-This is done via a \code{\link[=get_current_lamin_settings]{get_current_lamin_settings()}} to avoid importing Python
-\code{lamindb}
 }

--- a/man/get_current_lamin_settings.Rd
+++ b/man/get_current_lamin_settings.Rd
@@ -4,19 +4,17 @@
 \alias{get_current_lamin_settings}
 \title{Get current LaminDB settings}
 \usage{
-get_current_lamin_settings(minimal = FALSE)
+get_current_lamin_settings(minimal = FALSE, silent = FALSE)
 }
 \arguments{
 \item{minimal}{If \code{TRUE}, quickly extract a minimal list of important
 settings instead of converting the complete settings object}
+
+\item{silent}{Whether to suppress messages}
 }
 \value{
 A list of the current LaminDB settings
 }
 \description{
 Get the current LaminDB settings as an R list
-}
-\details{
-This is done using \code{\link[callr:r]{callr::r()}} to avoid importing Python \code{lamindb} in the
-global environment
 }

--- a/man/get_current_lamin_user.Rd
+++ b/man/get_current_lamin_user.Rd
@@ -4,7 +4,10 @@
 \alias{get_current_lamin_user}
 \title{Get current LaminDB user}
 \usage{
-get_current_lamin_user()
+get_current_lamin_user(silent = FALSE)
+}
+\arguments{
+\item{silent}{Whether to suppress messages}
 }
 \value{
 The handle of the current LaminDB user, or \code{NULL} invisibly if no
@@ -12,8 +15,4 @@ user is found
 }
 \description{
 Get the currently logged in LaminDB user
-}
-\details{
-This is done via \code{\link[=get_current_lamin_settings]{get_current_lamin_settings()}} to avoid importing Python
-\code{lamindb}
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -15,13 +15,14 @@ if (isTRUE(as.logical(Sys.getenv("NOT_CRAN", "false")))) {
   # Use a temporary test instance
   use_temporary_instance(
     test_name,
-    modules = "bionty",
+    modules = c("bionty", "pertdb"),
     add_timestamp = FALSE,
     envir = testthat::teardown_env()
   )
 
   # Import lamindb so we don't have to do it in every test
   ln <- import_module("lamindb")
+
   # Reset the default instance so we can connect to another
   withr::defer(options(LAMINR_DEFAULT_INSTANCE = NULL), testthat::teardown_env())
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -5,10 +5,7 @@ if (isTRUE(as.logical(Sys.getenv("NOT_CRAN", "false")))) {
 
   # Make sure we are using the ephemeral environment with lamindb
   withr::with_envvar(
-    c(
-      "RETICULATE_USE_MANAGED_VENV" = "yes",
-      "LAMINR_LAMINDB_OPTIONS" = "bionty" # Always include bionty for tests
-    ),
+    c("RETICULATE_USE_MANAGED_VENV" = "yes"),
     {
       require_lamindb()
       reticulate::py_config()

--- a/tests/testthat/test-Registry.R
+++ b/tests/testthat/test-Registry.R
@@ -1,7 +1,7 @@
 skip_on_cran()
 
 test_that("Wrapping a Registry works", {
-  expect_s3_class(ln$ULabel, "laminr.lamindb.models.record.Registry")
+  expect_s3_class(ln$ULabel, "laminr.lamindb.models.sqlrecord.Registry")
 })
 
 test_that("Calling a Registry works", {

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -66,6 +66,9 @@ test_that("check_requires() works with Python packages", {
 })
 
 test_that("check_default_instance() works", {
+  set_default_instance("test/test")
+  withr::defer(options(LAMINR_DEFAULT_INSTANCE = NULL))
+
   expect_error(check_default_instance())
 
   expect_warning(check_default_instance(alert = "warning"))
@@ -73,10 +76,14 @@ test_that("check_default_instance() works", {
   expect_message(check_default_instance(alert = "message"))
 
   expect_true(check_default_instance(alert = "none"))
+
 })
 
 test_that("check_default_instance() works with provided instance", {
-  expect_true(check_default_instance(get_current_lamin_instance()))
+  set_default_instance("test/test")
+  withr::defer(options(LAMINR_DEFAULT_INSTANCE = NULL))
+
+  expect_true(check_default_instance("test/test"))
 })
 
 test_that("check_instance_module()", {

--- a/tests/testthat/test-import.R
+++ b/tests/testthat/test-import.R
@@ -41,7 +41,7 @@ test_that("Importing pertdb works", {
 
   pt <- import_module("pertdb")
 
-  expect_s3_class(wl, "python.builtin.module")
+  expect_s3_class(pt, "python.builtin.module")
 })
 
 test_that("Importing clinicore works", {

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -9,7 +9,13 @@ withr::defer(
 
 test_that("install_lamindb() works", {
   withr::local_options(lifecycle_verbosity = "quiet")
-  expect_no_error(install_lamindb(envname = test_install_env, use = FALSE))
+  expect_no_error(
+    install_lamindb(
+      envname = test_install_env,
+      python_version = ">3.10,<3.14",
+      use = FALSE
+    )
+  )
 })
 
 test_that("install_lamindb() works with extra packages", {
@@ -17,6 +23,7 @@ test_that("install_lamindb() works with extra packages", {
   expect_no_error(
     install_lamindb(
       envname = test_install_env,
+      python_version = ">3.10,<3.14",
       extra_packages = c("bionty", "pertdb"),
       use = FALSE
     )

--- a/tests/testthat/test-unwrap-python.R
+++ b/tests/testthat/test-unwrap-python.R
@@ -1,7 +1,7 @@
 test_that("unwrap_python() works", {
   expect_s3_class(unwrap_python(ln), "python.builtin.module")
 
-  expect_s3_class(unwrap_python(ln$ULabel), "lamindb.models.record.Registry")
+  expect_s3_class(unwrap_python(ln$ULabel), "lamindb.models.sqlrecord.Registry")
 
   df <- data.frame(
     Letters = LETTERS[1:5],
@@ -31,9 +31,9 @@ test_that("unwrap_args_and_call() works", {
       )
     ),
     c(
-      "lamindb.models.record.Registry",
+      "lamindb.models.sqlrecord.Registry",
       "python.builtin.module",
-      "lamindb.models.record.Registry"
+      "lamindb.models.sqlrecord.Registry"
     )
   )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,10 +1,12 @@
 test_that("getting and setting LAMINR_DEFAULT_INSTANCE works", {
-  default_instance <- get_default_instance()
   current_instance <- get_current_lamin_instance()
+  op <- set_default_instance(current_instance)
+  withr::defer(suppressWarnings(options(op)))
+
+  default_instance <- get_default_instance()
   expect_identical(default_instance, current_instance)
 
-  op <- expect_warning(set_default_instance("new/instance"))
-  withr::defer(suppressWarnings(options(op)))
+  expect_warning(set_default_instance("new/instance"))
 
   expect_identical(get_default_instance(), "new/instance")
 })

--- a/tests/testthat/test-wrap-python.R
+++ b/tests/testthat/test-wrap-python.R
@@ -1,6 +1,7 @@
 test_that("wrap_python() works", {
   np <- reticulate::import("numpy", convert = FALSE)
-  expect_s3_class(wrap_python(np), "laminr.python.builtin.module")
+  expect_warning(wrapped_np <- wrap_python(np), "Failed to parse default string")
+  expect_s3_class(wrapped_np, "laminr.python.builtin.module")
 
   ndarray <- np$random$rand(4L, 4L)
   expect_s3_class(ndarray, "numpy.ndarray")

--- a/vignettes/articles/introduction.Rmd
+++ b/vignettes/articles/introduction.Rmd
@@ -52,6 +52,13 @@ lc$login()
 lc$connect("<account>/<instance>")
 ```
 
+Alternatively, connect after importing the **lamindb** module:
+
+```
+ln <- laminr::import_module("lamindb")
+ln$connect("<account>/<instance>")
+```
+
 ## Quickstart
 
 In an R session, transfer an scRNA-seq dataset from the `laminlabs/cellxgene` instance, compute marker genes with **{Seurat}**, and save results.


### PR DESCRIPTION
<!--
Improve the heading of your PR by adding an emoji, e.g.:

- ✨ New feature
- 🐛 Bug fix
- 🚸 UX

To add emojis to all your commits, use [gitmoji](https://gitmoji.dev/).

1. Install with:

npm i -g gitmoji-cli

OR

brew install gitmoji

2. Install the gitmoji git hook

gitmoji -i
-->

## Description

<!-- Briefly describe what this PR does. Use dot points or a check list if needed -->

Simplify connecting to an instance by removing checks made by **{laminr}** that are no longer needed with recent versions of **lamindb**. This enables connecting using `ln$connect()` (requires `lamindb>=2.3`).

**Other changes**

- The `get_current_lamin_*()` util helpers and `use_temporary_instance()` now work in the current session instead of using **{callr}**.
- Added `silent` argument to `get_current_lamin_*()` util helpers and `ignore_none` argument to `get_current_lamin_instance()`

## Checklist

**Before review**

- [x] Update and regenerate man pages
- [x] Add/update tests
- [x] Add/update examples in vignettes
- [x] Pass CI checks

**Before merge**

- [ ] Update `CHANGELOG`
